### PR TITLE
array deque

### DIFF
--- a/stack/array_deque.go
+++ b/stack/array_deque.go
@@ -28,7 +28,7 @@ func NewArrayDeque[T any]() *ArrayDeque[T] {
 func NewArrayDequeWithCap[T any](expectedCapacity int) *ArrayDeque[T] {
 	capacity := calculateCapacity(expectedCapacity)
 	return &ArrayDeque[T]{
-		elements: make([]T, capacity, capacity),
+		elements: make([]T, capacity),
 		head:     0,
 		tail:     0,
 	}
@@ -175,7 +175,7 @@ func (a *ArrayDeque[T]) doubleCapacity() error {
 	if newCapacity < 0 || newCapacity > maxCapacity {
 		return ErrOutOfCapacity
 	}
-	newElements := make([]T, newCapacity, newCapacity)
+	newElements := make([]T, newCapacity)
 	r := n - a.head
 	copy(newElements[0:r], a.elements[a.head:r+a.head])
 	copy(newElements[r:], a.elements[:a.tail+1])

--- a/stack/array_deque.go
+++ b/stack/array_deque.go
@@ -1,0 +1,204 @@
+package stack
+
+import (
+	"errors"
+)
+
+const (
+	minCapacity int = 1 << 4
+	maxCapacity int = 1 << 30
+)
+
+var (
+	ErrOutOfCapacity = errors.New("ekit: 超出最大容量限制")
+	ErrEmpty         = errors.New("ekit: deque 为空")
+)
+
+var (
+	_ Stack[any] = &ArrayDeque[any]{}
+	_ Queue[any] = &ArrayDeque[any]{}
+)
+
+// NewArrayDeque 构造一个最小容量的Deque
+func NewArrayDeque[T any]() *ArrayDeque[T] {
+	return NewArrayDequeWithCap[T](minCapacity)
+}
+
+// NewArrayDequeWithCap 构造一个期望容量的Deque
+func NewArrayDequeWithCap[T any](expectedCapacity int) *ArrayDeque[T] {
+	capacity := calculateCapacity(expectedCapacity)
+	return &ArrayDeque[T]{
+		elements: make([]T, capacity, capacity),
+		head:     0,
+		tail:     0,
+	}
+}
+
+func NewArrayDequeOf[T any](elements ...T) *ArrayDeque[T] {
+	length := len(elements)
+	deque := NewArrayDequeWithCap[T](length)
+	for _, val := range elements {
+		_ = deque.AddLast(val)
+	}
+	return deque
+}
+
+// ArrayDeque 基于切片实现的可扩容循环队列。
+//  1.相较于SDK中的list.List, ArrayDeque无需维护复杂的链表关系
+//  2.相较于SDK中的list.List, 基于切片的随机访问，可以快速获取数据
+//  3.相较于SDK中的list.List, 基于切片的连续性，可以降低内存的碎片化
+// 	4.此循环队列不是无限制添加的，容量限定范围为[1 << 4, 1 << 30]
+// 	5.此循环队列不是线程安全的，它不支持多线程的并发访问
+// 	6.实现了Queue和Stack接口，你可以将他作为栈或者队列使用
+//  7.ArrayDeque没有对空值作限制，但是不推荐向其中写入nil
+//  8.ArrayDeque具有扩容机制，并且容量始终为2的幂，这造成了内存空间的浪费，在使用前可以预估容量，减少扩容导致的内存浪费
+type ArrayDeque[T any] struct {
+	elements   []T
+	head, tail int
+	empty      T
+}
+
+func (a *ArrayDeque[T]) Front() (T, error) {
+	return a.GetFirst()
+}
+
+func (a *ArrayDeque[T]) Enqueue(t T) error {
+	return a.AddLast(t)
+}
+
+func (a *ArrayDeque[T]) Dequeue() (T, error) {
+	return a.RemoveFirst()
+}
+
+func (a *ArrayDeque[T]) Push(t T) error {
+	return a.AddLast(t)
+}
+
+func (a *ArrayDeque[T]) Pop() (T, error) {
+	return a.RemoveLast()
+}
+
+func (a *ArrayDeque[T]) Top() (T, error) {
+	return a.GetLast()
+}
+
+// AddFirst 从队首添加元素，如果失败，那么返回错误
+func (a *ArrayDeque[T]) AddFirst(t T) error {
+	a.head = (a.head - 1) & (a.Cap() - 1)
+	a.elements[a.head] = t
+	if a.head == a.tail {
+		err := a.doubleCapacity()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddLast 从尾部添加元素，如果失败，那么返回错误
+func (a *ArrayDeque[T]) AddLast(t T) error {
+	a.elements[a.tail] = t
+	a.tail = (a.tail + 1) & (a.Cap() - 1)
+	if a.head == a.tail {
+		err := a.doubleCapacity()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveFirst 删除第一个元素，如果为空，那么返回错误
+func (a *ArrayDeque[T]) RemoveFirst() (T, error) {
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	result = a.elements[a.head]
+	a.elements[a.head] = a.empty
+	a.head = (a.head + 1) & (a.Cap() - 1)
+	return result, nil
+}
+
+// RemoveLast 删除最后一个元素，如果为空，那么返回错误
+func (a *ArrayDeque[T]) RemoveLast() (T, error) {
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	a.tail = (a.tail - 1) & (a.Cap() - 1)
+	result = a.elements[a.tail]
+	a.elements[a.tail] = a.empty
+	return result, nil
+}
+
+// GetFirst 获取arrayDeque的队首元素，如果没有，那么返回错误
+func (a *ArrayDeque[T]) GetFirst() (T, error) {
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	result = a.elements[a.head]
+	return result, nil
+}
+
+// GetLast 获取arrayDeque末尾的元素，如果没有，那么返回ErrEmpty
+func (a *ArrayDeque[T]) GetLast() (T, error) {
+	var result T
+	if a.IsEmpty() {
+		return result, ErrEmpty
+	}
+	t := (a.tail - 1) & (a.Cap() - 1)
+	result = a.elements[t]
+	return result, nil
+}
+
+// Cap 返回arrayDeque此时的容量
+func (a *ArrayDeque[T]) Cap() int {
+	return cap(a.elements)
+}
+
+// Len 返回arrayDeque中的元素个数
+func (a *ArrayDeque[T]) Len() int {
+	return (a.tail - a.head) & (a.Cap() - 1)
+}
+
+// IsEmpty 返回arrayDeque是否为空
+func (a *ArrayDeque[T]) IsEmpty() bool {
+	return a.Len() == 0
+}
+
+// doubleCapacity 给arrayDeque扩容，如果容量超过了最大容量，那么返回错误
+func (a *ArrayDeque[T]) doubleCapacity() error {
+	n := a.Cap()
+	newCapacity := n << 1
+	if newCapacity < 0 || newCapacity > maxCapacity {
+		return ErrOutOfCapacity
+	}
+	newElements := make([]T, newCapacity, newCapacity)
+	r := n - a.head
+	copy(newElements[0:r], a.elements[a.head:r+a.head])
+	copy(newElements[r:], a.elements[:a.tail+1])
+	a.elements = newElements
+	a.head = 0
+	a.tail = n
+	return nil
+}
+
+// calculateCapacity 从给定的预期容量中计算一个合适的预期容量
+func calculateCapacity(expected int) int {
+	initialCapacity := minCapacity
+	if expected > initialCapacity {
+		initialCapacity = expected
+		initialCapacity |= initialCapacity >> 1
+		initialCapacity |= initialCapacity >> 2
+		initialCapacity |= initialCapacity >> 4
+		initialCapacity |= initialCapacity >> 8
+		initialCapacity |= initialCapacity >> 16
+		initialCapacity++
+		if initialCapacity > maxCapacity {
+			initialCapacity = maxCapacity
+		}
+	}
+	return initialCapacity
+}

--- a/stack/array_deque_test.go
+++ b/stack/array_deque_test.go
@@ -1,0 +1,510 @@
+package stack
+
+import (
+	"container/list"
+	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"testing"
+)
+
+func TestArrayDeque_AddLast(t *testing.T) {
+	testClasses := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		loopNum int
+		wantErr error
+		wantLen int
+	}{
+		{
+			name:    "向尾部添加，并对比元素数量",
+			deque:   NewArrayDeque[int](),
+			loopNum: 1 << 16,
+			wantLen: 1 << 16,
+		},
+		{
+			name:    "向末尾添加，直到达到队列的最大容量",
+			deque:   NewArrayDequeWithCap[int](1 << 29),
+			loopNum: (1 << 29) - 1,
+			wantErr: ErrOutOfCapacity,
+			wantLen: (1 << 29) - 1,
+		},
+	}
+	for _, tc := range testClasses {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < tc.loopNum; i++ {
+				err := tc.deque.AddLast(i)
+				if err != nil {
+					t.Logf("error: %v", err)
+					assert.Equal(t, tc.wantErr, err)
+					break
+				}
+			}
+			assert.Equal(t, tc.wantLen, tc.deque.Len())
+		})
+	}
+}
+
+func TestArrayDeque_AddFirst(t *testing.T) {
+	testClasses := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		loopNum int
+		wantErr error
+		wantLen int
+	}{
+		{
+			name:    "向头部添加，并对比元素数量",
+			deque:   NewArrayDeque[int](),
+			loopNum: 1 << 16,
+			wantLen: 1 << 16,
+		},
+		{
+			name:    "向头部添加，直到达到队列的最大容量",
+			deque:   NewArrayDequeWithCap[int](1 << 29),
+			loopNum: (1 << 29) - 1,
+			wantErr: ErrOutOfCapacity,
+			wantLen: (1 << 29) - 1,
+		},
+	}
+	for _, tc := range testClasses {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < tc.loopNum; i++ {
+				err := tc.deque.AddFirst(i)
+				if err != nil {
+					assert.Equal(t, tc.wantErr, err)
+					break
+				}
+			}
+			assert.Equal(t, tc.wantLen, tc.deque.Len())
+		})
+	}
+}
+
+func TestArrayDeque_GetFirst(t *testing.T) {
+	testClass := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		newVal  int
+		wantErr error
+	}{
+		{
+			name:    "get first where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:    "get first where deque not empty",
+			deque:   NewArrayDeque[int](),
+			newVal:  100,
+			wantErr: nil,
+		},
+	}
+	for _, tc := range testClass {
+		val := tc.newVal
+		if val != 0 {
+			err := tc.deque.AddLast(val)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.GetFirst()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+		} else {
+			assert.Equal(t, first, tc.newVal)
+		}
+	}
+}
+
+func TestArrayDeque_GetLast(t *testing.T) {
+	testClass := []struct {
+		name    string
+		deque   *ArrayDeque[int]
+		newVal  int
+		wantErr error
+	}{
+		{
+			name:    "get first where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:    "get first where deque not empty",
+			deque:   NewArrayDeque[int](),
+			newVal:  100,
+			wantErr: nil,
+		},
+	}
+	for _, tc := range testClass {
+		val := tc.newVal
+		if val != 0 {
+			err := tc.deque.AddFirst(val)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.GetLast()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+		} else {
+			assert.Equal(t, first, tc.newVal)
+		}
+	}
+}
+
+func TestArrayDeque_RemoveFirst(t *testing.T) {
+	testClasses := []struct {
+		name     string
+		deque    *ArrayDeque[int]
+		wantErr  error
+		newValue int
+	}{
+		{
+			name:    "remove first where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:     "remove a value",
+			deque:    NewArrayDeque[int](),
+			wantErr:  nil,
+			newValue: 1,
+		},
+	}
+	for _, tc := range testClasses {
+		value := tc.newValue
+		if value != 0 {
+			err := tc.deque.AddLast(tc.newValue)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.RemoveFirst()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+			assert.True(t, tc.deque.IsEmpty())
+		} else {
+			assert.Equal(t, first, tc.newValue)
+		}
+	}
+}
+
+func TestArrayDeque_RemoveLast(t *testing.T) {
+	testClasses := []struct {
+		name     string
+		deque    *ArrayDeque[int]
+		wantErr  error
+		newValue int
+	}{
+		{
+			name:    "remove last where deque is empty",
+			deque:   NewArrayDeque[int](),
+			wantErr: ErrEmpty,
+		},
+		{
+			name:     "remove a value",
+			deque:    NewArrayDeque[int](),
+			wantErr:  nil,
+			newValue: 1,
+		},
+	}
+	for _, tc := range testClasses {
+		value := tc.newValue
+		if value != 0 {
+			err := tc.deque.AddFirst(tc.newValue)
+			assert.Nil(t, err)
+		}
+		first, err := tc.deque.RemoveLast()
+		if err != nil {
+			assert.Equal(t, tc.wantErr, err)
+			assert.True(t, tc.deque.IsEmpty())
+		} else {
+			assert.Equal(t, first, tc.newValue)
+		}
+	}
+}
+
+func TestArrayDeque_AsStack(t *testing.T) {
+	testClasses := []struct {
+		name         string
+		deque        *ArrayDeque[int]
+		compareStack *list.List
+		pushNum      int
+		wantErr      error
+	}{
+		{
+			name:         "push and pop",
+			deque:        NewArrayDeque[int](),
+			compareStack: list.New(),
+			pushNum:      10000,
+			wantErr:      nil,
+		},
+	}
+	for _, tc := range testClasses {
+		deque := tc.deque
+		stack := tc.compareStack
+		for i := 0; i < tc.pushNum; i++ {
+			err := deque.Push(i)
+			assert.Nil(t, err)
+			stack.PushBack(i)
+		}
+		for tc.deque.Len() > 0 {
+			pop, err := deque.Pop()
+			assert.Nil(t, err)
+			compare := stack.Remove(stack.Back()).(int)
+			assert.Equal(t, compare, pop)
+		}
+		assert.True(t, deque.IsEmpty())
+		assert.True(t, stack.Len() == 0)
+	}
+}
+
+func TestArrayDeque_AsQueue(t *testing.T) {
+	testClasses := []struct {
+		name         string
+		deque        *ArrayDeque[int]
+		compareStack *list.List
+		pushNum      int
+		wantErr      error
+	}{
+		{
+			name:         "push and pop",
+			deque:        NewArrayDeque[int](),
+			compareStack: list.New(),
+			pushNum:      10000,
+			wantErr:      nil,
+		},
+	}
+	for _, tc := range testClasses {
+		deque := tc.deque
+		stack := tc.compareStack
+		for i := 0; i < tc.pushNum; i++ {
+			err := deque.Enqueue(i)
+			assert.Nil(t, err)
+			stack.PushBack(i)
+		}
+		for tc.deque.Len() > 0 {
+			front, err := deque.Dequeue()
+			assert.Nil(t, err)
+			compare := stack.Remove(stack.Front()).(int)
+			assert.Equal(t, compare, front)
+		}
+		t.Logf("deque is empty: %v", deque.IsEmpty())
+		assert.True(t, deque.IsEmpty())
+		assert.True(t, stack.Len() == 0)
+	}
+}
+
+func TestArrayDeque_Cap(t *testing.T) {
+	testClasses := []struct {
+		name        string
+		deque       *ArrayDeque[int]
+		newVals     []int
+		expectedCap int
+	}{
+		{
+			name:        "test init cap",
+			deque:       NewArrayDeque[int](),
+			newVals:     make([]int, 0, 0),
+			expectedCap: 16,
+		},
+		{
+			name:        "test init with expected cap",
+			deque:       NewArrayDequeWithCap[int](20),
+			newVals:     make([]int, 0, 0),
+			expectedCap: 32,
+		},
+		{
+			name:        "test capacity grow up",
+			deque:       NewArrayDeque[int](),
+			newVals:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			expectedCap: 32,
+		},
+		{
+			name:        "test init with expected cap and not grow",
+			deque:       NewArrayDequeWithCap[int](17),
+			newVals:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			expectedCap: 32,
+		},
+	}
+	for _, tc := range testClasses {
+		deque := tc.deque
+		for _, val := range tc.newVals {
+			err := deque.Push(val)
+			assert.Nil(t, err)
+		}
+		assert.Equal(t, tc.expectedCap, deque.Cap())
+	}
+}
+
+func TestArrayDeque_RandomOps(t *testing.T) {
+	testClasses := []struct {
+		name string
+		ops  func(arrayDeque *ArrayDeque[int], list *list.List)
+	}{
+		{
+			name: "AddLast",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				val := rand.Int()
+				err := arrayDeque.AddLast(val)
+				if err != nil {
+					assert.Equal(t, ErrOutOfCapacity, err)
+				} else {
+					list.PushBack(val)
+				}
+			},
+		},
+		{
+			name: "GetLast",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				last, err := arrayDeque.GetLast()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Back().Value.(int)
+					assert.Equal(t, val, last)
+				}
+			},
+		},
+		{
+			name: "RemoveLast",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				last, err := arrayDeque.RemoveLast()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Remove(list.Back()).(int)
+					assert.Equal(t, val, last)
+				}
+			},
+		},
+		{
+			name: "AddFirst",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				val := rand.Int()
+				err := arrayDeque.AddFirst(val)
+				if err != nil {
+					assert.Equal(t, ErrOutOfCapacity, err)
+				} else {
+					list.PushFront(val)
+				}
+			},
+		},
+		{
+			name: "GetFirst",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				first, err := arrayDeque.GetFirst()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Front().Value.(int)
+					assert.Equal(t, val, first)
+				}
+			},
+		},
+		{
+			name: "RemoveFirst",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				first, err := arrayDeque.RemoveFirst()
+				if err != nil {
+					assert.Equal(t, ErrEmpty, err)
+					assert.True(t, arrayDeque.IsEmpty())
+				} else {
+					val := list.Remove(list.Front()).(int)
+					assert.Equal(t, val, first)
+				}
+			},
+		},
+		{
+			name: "IsEmpty",
+			ops: func(arrayDeque *ArrayDeque[int], list *list.List) {
+				empty := arrayDeque.IsEmpty()
+				listEmpty := list.Len() == 0
+				assert.Equal(t, empty, listEmpty)
+			},
+		},
+	}
+	NewArrayDeque[int]()
+	opsNum := 10000000
+	opsCount := len(testClasses)
+	deque := NewArrayDeque[int]()
+	stack := list.New()
+	for i := 0; i < opsNum; i++ {
+		intn := rand.Int()
+		ops := intn % opsCount
+		testClass := testClasses[ops]
+		testClass.ops(deque, stack)
+	}
+}
+
+func BenchmarkArrayDeque_RandomOps(b *testing.B) {
+	deque := NewArrayDeque[int]()
+	stack := list.New()
+	b.Run("deque", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ops := rand.Int()
+			arrayDequeRandomOps(deque, ops)
+		}
+	})
+	b.Run("stack", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ops := rand.Int()
+			listRandomOps(stack, ops)
+		}
+	})
+}
+
+func arrayDequeRandomOps(deque *ArrayDeque[int], ops int) {
+	oprations := []func(d *ArrayDeque[int]){
+		func(d1 *ArrayDeque[int]) {
+			val := rand.Int()
+			d1.AddLast(val)
+		},
+		func(d2 *ArrayDeque[int]) {
+			d2.GetLast()
+		},
+		func(d3 *ArrayDeque[int]) {
+			d3.RemoveLast()
+		},
+		func(d4 *ArrayDeque[int]) {
+			val := rand.Int()
+			d4.AddFirst(val)
+		},
+		func(d5 *ArrayDeque[int]) {
+			d5.GetFirst()
+		},
+		func(d6 *ArrayDeque[int]) {
+			d6.RemoveFirst()
+		},
+	}
+	idx := ops % len(oprations)
+	oprations[idx](deque)
+}
+
+func listRandomOps(stack *list.List, ops int) {
+	oprations := []func(d *list.List){
+		func(d1 *list.List) {
+			val := rand.Int()
+			d1.PushFront(val)
+		},
+		func(d2 *list.List) {
+			d2.Back()
+		},
+		func(d3 *list.List) {
+			if d3.Len() > 0 {
+				d3.Remove(d3.Back())
+			}
+		},
+		func(d4 *list.List) {
+			val := rand.Int()
+			d4.PushBack(val)
+		},
+		func(d5 *list.List) {
+			d5.Front()
+		},
+		func(d6 *list.List) {
+			if d6.Len() > 0 {
+				d6.Remove(d6.Front())
+			}
+		},
+	}
+	idx := ops % len(oprations)
+	oprations[idx](stack)
+}

--- a/stack/array_deque_test.go
+++ b/stack/array_deque_test.go
@@ -299,13 +299,13 @@ func TestArrayDeque_Cap(t *testing.T) {
 		{
 			name:        "test init cap",
 			deque:       NewArrayDeque[int](),
-			newVals:     make([]int, 0, 0),
+			newVals:     make([]int, 0),
 			expectedCap: 16,
 		},
 		{
 			name:        "test init with expected cap",
 			deque:       NewArrayDequeWithCap[int](20),
-			newVals:     make([]int, 0, 0),
+			newVals:     make([]int, 0),
 			expectedCap: 32,
 		},
 		{

--- a/stack/types.go
+++ b/stack/types.go
@@ -1,0 +1,18 @@
+package stack
+
+import "github.com/gotomicro/ekit/queue"
+
+type Stack[T any] interface {
+	// Push 将元素入栈，如果无法入栈，那么返回错误
+	Push(t T) error
+	// Pop 弹出栈顶元素, 如果此时栈中没有数据，那么返回错误
+	Pop() (T, error)
+	// Top 查看栈顶元素，但是不删除，如果栈中没有数据，那么返回错误
+	Top() (T, error)
+}
+
+type Queue[T any] interface {
+	// Front 查看队首元素，但是不删除，如果队列中没有数据，那么返回错误
+	Front() (T, error)
+	queue.Queue[T]
+}


### PR DESCRIPTION
[XnCluster](https://github.com/XnCluster) commented [43 minutes ago](https://github.com/gotomicro/ekit/pull/153#issue-1573560766)
基于切片实现的可扩容循环队列
1.相较于SDK中的list.List, 无需维护链表关系
2.相较于SDK中的list.List, 基于切片的随机访问，可以快速获取数据
3.相较于SDK中的list.List, 基于切片的连续性，可以降低内存的碎片化
4.此循环队列不是无限制添加的，容量限定范围为[1 << 4, 1 << 30]
5.此循环队列不是线程安全的，它不支持多线程的并发访问
6.实现了Queue和Stack接口，你可以将他作为栈或者队列使用
7.ArrayDeque没有对空值作限制，使用时应该注意nil的处理
8.ArrayDeque具有扩容机制，并且容量始终为2的幂，这造成了内存空间的浪费，在使用前可以预估容量，减少扩容导致的内存浪费