### PR TITLE
copier: ReflectCopier 支持忽略字段

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -10,6 +10,7 @@
 - [mapx: MutipleTreeMap](https://github.com/ecodeclub/ekit/pull/187)
 - [mapx: 为 MultipleMap 添加 PutVals 方法](https://github.com/ecodeclub/ekit/pull/189)
 - [mapx: LinkedMap 特性](https://github.com/ecodeclub/ekit/pull/191)
+- [copier: ReflectCopier 支持忽略字段](https://github.com/ecodeclub/ekit/pull/196)
 
 # v0.0.7
 - [slice: FilterDelete](https://github.com/ecodeclub/ekit/pull/152)

--- a/bean/copier/copy.go
+++ b/bean/copier/copy.go
@@ -37,20 +37,16 @@ type options struct {
 	ignoreFields *set.MapSet[string]
 }
 
-func newOptions(opts ...option.Option[options]) *options {
-	opt := &options{}
-	option.Apply(opt, opts...)
-	return opt
-}
-
-func initIgnoreFields(size int) option.Option[options] {
-	return func(opt *options) {
-		opt.ignoreFields = set.NewMapSet[string](size)
-	}
+func newOptions() *options {
+	return &options{}
 }
 
 // InIgnoreFields 判断 str 是不是在 ignoreFields 里面
 func (r *options) InIgnoreFields(str string) bool {
+	// 如果没有设置过忽略的字段的话，ignoreFields 就有可能是 nil，这里需要判断一下
+	if r.ignoreFields == nil {
+		return false
+	}
 	return r.ignoreFields.Exist(str)
 }
 
@@ -59,6 +55,10 @@ func IgnoreFields(fields ...string) option.Option[options] {
 	return func(opt *options) {
 		if len(fields) < 1 {
 			return
+		}
+		// 需要用的时候再延迟初始化 ignoreFields
+		if opt.ignoreFields == nil {
+			opt.ignoreFields = set.NewMapSet[string](10)
 		}
 		for i := 0; i < len(fields); i++ {
 			opt.ignoreFields.Add(fields[i])

--- a/bean/copier/copy.go
+++ b/bean/copier/copy.go
@@ -58,7 +58,7 @@ func IgnoreFields(fields ...string) option.Option[options] {
 		}
 		// 需要用的时候再延迟初始化 ignoreFields
 		if opt.ignoreFields == nil {
-			opt.ignoreFields = set.NewMapSet[string](10)
+			opt.ignoreFields = set.NewMapSet[string](len(fields))
 		}
 		for i := 0; i < len(fields); i++ {
 			opt.ignoreFields.Add(fields[i])

--- a/bean/copier/copy.go
+++ b/bean/copier/copy.go
@@ -37,9 +37,15 @@ type options struct {
 	ignoreFields *set.MapSet[string]
 }
 
-func newOptions() *options {
-	return &options{
-		ignoreFields: set.NewMapSet[string](10),
+func newOptions(opts ...option.Option[options]) *options {
+	opt := &options{}
+	option.Apply(opt, opts...)
+	return opt
+}
+
+func initIgnoreFields(size int) option.Option[options] {
+	return func(opt *options) {
+		opt.ignoreFields = set.NewMapSet[string](size)
 	}
 }
 
@@ -50,12 +56,12 @@ func (r *options) InIgnoreFields(str string) bool {
 
 // IgnoreFields 设置复制时要忽略的字段（option 设计模式）
 func IgnoreFields(fields ...string) option.Option[options] {
-	return func(opts *options) {
+	return func(opt *options) {
 		if len(fields) < 1 {
 			return
 		}
 		for i := 0; i < len(fields); i++ {
-			opts.ignoreFields.Add(fields[i])
+			opt.ignoreFields.Add(fields[i])
 		}
 	}
 }

--- a/bean/copier/copy.go
+++ b/bean/copier/copy.go
@@ -21,7 +21,34 @@ package copier
 // 这种设计设计，即使用 *Src 和 *Dst 可能加剧内存逃逸
 type Copier[Src any, Dst any] interface {
 	// CopyTo 将 src 中的数据复制到 dst 中
-	CopyTo(src *Src, dst *Dst) error
+	CopyTo(src *Src, dst *Dst, opts ...Option) error
 	// Copy 将创建一个 Dst 的实例，并且将 Src 中的数据复制过去
-	Copy(src *Src) (*Dst, error)
+	Copy(src *Src, opts ...Option) (*Dst, error)
+}
+
+// options 执行复制操作时的可选配置
+type options struct {
+	// ignoreFields 执行复制操作时，需要忽略的字段
+	ignoreFields []string
+}
+
+// InIgnoreFields 判断 str 是不是在 ignoreFields 里面
+func (r *options) InIgnoreFields(str string) bool {
+	if len(r.ignoreFields) < 1 {
+		return false
+	}
+	for _, s := range r.ignoreFields {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
+type Option func(*options)
+
+func IgnoreFields(fields ...string) Option {
+	return func(opts *options) {
+		opts.ignoreFields = append(opts.ignoreFields, fields...)
+	}
 }

--- a/bean/copier/reflect_copier.go
+++ b/bean/copier/reflect_copier.go
@@ -159,7 +159,7 @@ func (r *ReflectCopier[Src, Dst]) Copy(src *Src, opts ...option.Option[options])
 // 3. 如果 Src 和 Dst 中匹配的字段，其类型都是结构体，或者都是结构体指针，则会深入复制
 // 4. 否则，忽略字段
 func (r *ReflectCopier[Src, Dst]) CopyTo(src *Src, dst *Dst, opts ...option.Option[options]) error {
-	opt := newOptions(initIgnoreFields(10))
+	opt := newOptions()
 	option.Apply(opt, opts...)
 	r.options = opt
 

--- a/bean/copier/reflect_copier.go
+++ b/bean/copier/reflect_copier.go
@@ -15,6 +15,7 @@
 package copier
 
 import (
+	"github.com/ecodeclub/ekit/bean/option"
 	"reflect"
 )
 
@@ -145,7 +146,7 @@ func createFieldNodes(root *fieldNode, srcTyp, dstTyp reflect.Type) error {
 	return nil
 }
 
-func (r *ReflectCopier[Src, Dst]) Copy(src *Src, opts ...Option) (*Dst, error) {
+func (r *ReflectCopier[Src, Dst]) Copy(src *Src, opts ...option.Option[options]) (*Dst, error) {
 	dst := new(Dst)
 	err := r.CopyTo(src, dst, opts...)
 	return dst, err
@@ -157,14 +158,9 @@ func (r *ReflectCopier[Src, Dst]) Copy(src *Src, opts ...Option) (*Dst, error) {
 // 2. 如果 Src 和 Dst 中匹配的字段，其类型是基本类型（及其指针）或者内置类型（及其指针），并且类型一样，则直接用 Src 的值
 // 3. 如果 Src 和 Dst 中匹配的字段，其类型都是结构体，或者都是结构体指针，则会深入复制
 // 4. 否则，忽略字段
-func (r *ReflectCopier[Src, Dst]) CopyTo(src *Src, dst *Dst, opts ...Option) error {
-	//
-	opt := &options{}
-	if 0 < len(opts) {
-		for i := len(opts) - 1; i >= 0; i-- {
-			opts[i](opt)
-		}
-	}
+func (r *ReflectCopier[Src, Dst]) CopyTo(src *Src, dst *Dst, opts ...option.Option[options]) error {
+	opt := newOptions()
+	option.Apply(opt, opts...)
 	r.options = opt
 
 	return r.copyToWithTree(src, dst)

--- a/bean/copier/reflect_copier.go
+++ b/bean/copier/reflect_copier.go
@@ -159,7 +159,7 @@ func (r *ReflectCopier[Src, Dst]) Copy(src *Src, opts ...option.Option[options])
 // 3. 如果 Src 和 Dst 中匹配的字段，其类型都是结构体，或者都是结构体指针，则会深入复制
 // 4. 否则，忽略字段
 func (r *ReflectCopier[Src, Dst]) CopyTo(src *Src, dst *Dst, opts ...option.Option[options]) error {
-	opt := newOptions()
+	opt := newOptions(initIgnoreFields(10))
 	option.Apply(opt, opts...)
 	r.options = opt
 

--- a/bean/copier/reflect_copier.go
+++ b/bean/copier/reflect_copier.go
@@ -15,8 +15,9 @@
 package copier
 
 import (
-	"github.com/ecodeclub/ekit/bean/option"
 	"reflect"
+
+	"github.com/ecodeclub/ekit/bean/option"
 )
 
 // ReflectCopier 基于反射的实现

--- a/bean/copier/reflect_copier_test.go
+++ b/bean/copier/reflect_copier_test.go
@@ -505,6 +505,581 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 			wantDst: &SpecialDst2{A: 1},
 		},
+		{
+			name: "simple struct with ignore",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SimpleSrc{
+					Name:    "大明",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"Tom", "Jerry"},
+				}, IgnoreFields("Age"))
+			},
+			wantDst: &SimpleDst{
+				Name:    "大明",
+				Age:     nil,
+				Friends: []string{"Tom", "Jerry"},
+			},
+		},
+		{
+			name: "simple struct with ignore 2",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SimpleSrc{
+					Name:    "大明",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"Tom", "Jerry"},
+				}, IgnoreFields("Age"), IgnoreFields("Friends"))
+			},
+			wantDst: &SimpleDst{
+				Name:    "大明",
+				Age:     nil,
+				Friends: nil,
+			},
+		},
+		{
+			name: "simple struct with ignore 3",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SimpleSrc{
+					Name:    "大明",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"Tom", "Jerry"},
+				}, IgnoreFields("Name"), IgnoreFields("Age"), IgnoreFields("Friends"))
+			},
+			wantDst: &SimpleDst{},
+		},
+		{
+			name: "simple struct 空切片, 空指针 with ignore",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SimpleSrc{
+					Name: "大明",
+				}, IgnoreFields("Name"))
+			},
+			wantDst: &SimpleDst{
+				Name: "",
+			},
+		},
+		{
+			name: "组合 struct with ignore",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&EmbedSrc{
+					SimpleSrc: SimpleSrc{
+						Name:    "xiaoli",
+						Age:     ekit.ToPtr[int](19),
+						Friends: []string{},
+					},
+					BasicSrc: &BasicSrc{
+						Name:    "xiaowang",
+						Age:     20,
+						CNumber: complex(2, 2),
+					},
+				}, IgnoreFields("Age"))
+			},
+			wantDst: &EmbedDst{
+				SimpleSrc: SimpleSrc{
+					Name:    "xiaoli",
+					Age:     nil,
+					Friends: []string{},
+				},
+				BasicSrc: &BasicSrc{
+					Name:    "xiaowang",
+					Age:     0,
+					CNumber: complex(2, 2),
+				},
+			},
+		},
+		{
+			name: "组合 struct with ignore 2",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&EmbedSrc{
+					SimpleSrc: SimpleSrc{
+						Name:    "xiaoli",
+						Age:     ekit.ToPtr[int](19),
+						Friends: []string{},
+					},
+					BasicSrc: &BasicSrc{
+						Name:    "xiaowang",
+						Age:     20,
+						CNumber: complex(2, 2),
+					},
+				}, IgnoreFields("CNumber"))
+			},
+			wantDst: &EmbedDst{
+				SimpleSrc: SimpleSrc{
+					Name:    "xiaoli",
+					Age:     ekit.ToPtr[int](19),
+					Friends: []string{},
+				},
+				BasicSrc: &BasicSrc{
+					Name:    "xiaowang",
+					Age:     20,
+					CNumber: complex(0, 0),
+				},
+			},
+		},
+		{
+			name: "组合 struct with ignore 3",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&EmbedSrc{
+					SimpleSrc: SimpleSrc{
+						Name:    "xiaoli",
+						Age:     ekit.ToPtr[int](19),
+						Friends: []string{},
+					},
+					BasicSrc: &BasicSrc{
+						Name:    "xiaowang",
+						Age:     20,
+						CNumber: complex(2, 2),
+					},
+				}, IgnoreFields("SimpleSrc"))
+			},
+			wantDst: &EmbedDst{
+				SimpleSrc: SimpleSrc{},
+				BasicSrc: &BasicSrc{
+					Name:    "xiaowang",
+					Age:     20,
+					CNumber: complex(2, 2),
+				},
+			},
+		},
+		{
+			name: "组合 struct with ignore 4",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&EmbedSrc{
+					SimpleSrc: SimpleSrc{
+						Name:    "xiaoli",
+						Age:     ekit.ToPtr[int](19),
+						Friends: []string{},
+					},
+					BasicSrc: &BasicSrc{
+						Name:    "xiaowang",
+						Age:     20,
+						CNumber: complex(2, 2),
+					},
+				}, IgnoreFields("BasicSrc"))
+			},
+			wantDst: &EmbedDst{
+				SimpleSrc: SimpleSrc{
+					Name:    "xiaoli",
+					Age:     ekit.ToPtr[int](19),
+					Friends: []string{},
+				},
+				BasicSrc: nil,
+			},
+		},
+		{
+			name: "复杂 Struct with ignore",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&ComplexSrc{
+					Simple: SimpleSrc{
+						Name:    "xiaohong",
+						Age:     ekit.ToPtr[int](18),
+						Friends: []string{"ha", "ha", "le"},
+					},
+					Embed: &EmbedSrc{
+						SimpleSrc: SimpleSrc{
+							Name:    "xiaopeng",
+							Age:     ekit.ToPtr[int](88),
+							Friends: []string{"la", "ha", "le"},
+						},
+						BasicSrc: &BasicSrc{
+							Name:    "wang",
+							Age:     22,
+							CNumber: complex(2, 1),
+						},
+					},
+					BasicSrc: BasicSrc{
+						Name:    "wang11",
+						Age:     22,
+						CNumber: complex(2, 1),
+					},
+				}, IgnoreFields("Age"))
+			},
+			wantDst: &ComplexDst{
+				Simple: SimpleDst{
+					Name:    "xiaohong",
+					Age:     nil,
+					Friends: []string{"ha", "ha", "le"},
+				},
+				Embed: &EmbedDst{
+					SimpleSrc: SimpleSrc{
+						Name:    "xiaopeng",
+						Age:     nil,
+						Friends: []string{"la", "ha", "le"},
+					},
+					BasicSrc: &BasicSrc{
+						Name:    "wang",
+						Age:     0,
+						CNumber: complex(2, 1),
+					},
+				},
+				BasicSrc: BasicSrc{
+					Name:    "wang11",
+					Age:     0,
+					CNumber: complex(2, 1),
+				},
+			},
+		},
+		{
+			name: "复杂 Struct with ignore 2",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&ComplexSrc{
+					Simple: SimpleSrc{
+						Name:    "xiaohong",
+						Age:     ekit.ToPtr[int](18),
+						Friends: []string{"ha", "ha", "le"},
+					},
+					Embed: &EmbedSrc{
+						SimpleSrc: SimpleSrc{
+							Name:    "xiaopeng",
+							Age:     ekit.ToPtr[int](88),
+							Friends: []string{"la", "ha", "le"},
+						},
+						BasicSrc: &BasicSrc{
+							Name:    "wang",
+							Age:     22,
+							CNumber: complex(2, 1),
+						},
+					},
+					BasicSrc: BasicSrc{
+						Name:    "wang11",
+						Age:     22,
+						CNumber: complex(2, 1),
+					},
+				}, IgnoreFields("SimpleSrc"))
+			},
+			wantDst: &ComplexDst{
+				Simple: SimpleDst{
+					Name:    "xiaohong",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"ha", "ha", "le"},
+				},
+				Embed: &EmbedDst{
+					SimpleSrc: SimpleSrc{},
+					BasicSrc: &BasicSrc{
+						Name:    "wang",
+						Age:     22,
+						CNumber: complex(2, 1),
+					},
+				},
+				BasicSrc: BasicSrc{
+					Name:    "wang11",
+					Age:     22,
+					CNumber: complex(2, 1),
+				},
+			},
+		},
+		{
+			name: "复杂 Struct with ignore 3",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&ComplexSrc{
+					Simple: SimpleSrc{
+						Name:    "xiaohong",
+						Age:     ekit.ToPtr[int](18),
+						Friends: []string{"ha", "ha", "le"},
+					},
+					Embed: &EmbedSrc{
+						SimpleSrc: SimpleSrc{
+							Name:    "xiaopeng",
+							Age:     ekit.ToPtr[int](88),
+							Friends: []string{"la", "ha", "le"},
+						},
+						BasicSrc: &BasicSrc{
+							Name:    "wang",
+							Age:     22,
+							CNumber: complex(2, 1),
+						},
+					},
+					BasicSrc: BasicSrc{
+						Name:    "wang11",
+						Age:     22,
+						CNumber: complex(2, 1),
+					},
+				}, IgnoreFields("BasicSrc"))
+			},
+			wantDst: &ComplexDst{
+				Simple: SimpleDst{
+					Name:    "xiaohong",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"ha", "ha", "le"},
+				},
+				Embed: &EmbedDst{
+					SimpleSrc: SimpleSrc{
+						Name:    "xiaopeng",
+						Age:     ekit.ToPtr[int](88),
+						Friends: []string{"la", "ha", "le"},
+					},
+					BasicSrc: nil,
+				},
+				BasicSrc: BasicSrc{},
+			},
+		},
+		{
+			name: "复杂 Struct with ignore 4",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&ComplexSrc{
+					Simple: SimpleSrc{
+						Name:    "xiaohong",
+						Age:     ekit.ToPtr[int](18),
+						Friends: []string{"ha", "ha", "le"},
+					},
+					Embed: &EmbedSrc{
+						SimpleSrc: SimpleSrc{
+							Name:    "xiaopeng",
+							Age:     ekit.ToPtr[int](88),
+							Friends: []string{"la", "ha", "le"},
+						},
+						BasicSrc: &BasicSrc{
+							Name:    "wang",
+							Age:     22,
+							CNumber: complex(2, 1),
+						},
+					},
+					BasicSrc: BasicSrc{
+						Name:    "wang11",
+						Age:     22,
+						CNumber: complex(2, 1),
+					},
+				}, IgnoreFields("Embed"))
+			},
+			wantDst: &ComplexDst{
+				Simple: SimpleDst{
+					Name:    "xiaohong",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"ha", "ha", "le"},
+				},
+				Embed: nil,
+				BasicSrc: BasicSrc{
+					Name:    "wang11",
+					Age:     22,
+					CNumber: complex(2, 1),
+				},
+			},
+		},
+		{
+			name: "特殊类型 with ignore",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SpecialSrc, SpecialDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SpecialSrc{
+					Arr: [3]float32{1, 2, 3},
+					M: map[string]int{
+						"ha": 1,
+						"o":  2,
+					},
+				}, IgnoreFields("Arr"))
+			},
+			wantDst: &SpecialDst{
+				Arr: [3]float32{},
+				M: map[string]int{
+					"ha": 1,
+					"o":  2,
+				},
+			},
+		},
+		{
+			name: "特殊类型 with ignore 2",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SpecialSrc, SpecialDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SpecialSrc{
+					Arr: [3]float32{1, 2, 3},
+					M: map[string]int{
+						"ha": 1,
+						"o":  2,
+					},
+				}, IgnoreFields("M"))
+			},
+			wantDst: &SpecialDst{
+				Arr: [3]float32{1, 2, 3},
+				M:   nil,
+			},
+		},
+		{
+			name: "dst 有额外字段 with ignore",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[DiffSrc, DiffDst]()
+				if err != nil {
+					return nil, err
+				}
+				dst := &DiffDst{
+					A: "66",
+					B: 1,
+					d: SimpleSrc{
+						Name: "wodemingzi",
+						Age:  ekit.ToPtr(int(10)),
+					},
+					G: BasicSrc{
+						Name:    "nidemingzi",
+						Age:     23,
+						CNumber: complex(1, 2),
+					},
+				}
+				err = copier.CopyTo(&DiffSrc{
+					A: "xiaowang",
+					B: 100,
+					c: SimpleSrc{
+						Name: "66",
+						Age:  ekit.ToPtr[int](100),
+					},
+					F: BasicSrc{
+						Name:    "good name",
+						Age:     200,
+						CNumber: complex(2, 2),
+					},
+				}, dst, IgnoreFields("A"))
+				return dst, err
+			},
+			wantDst: &DiffDst{
+				A: "66",
+				B: 100,
+				d: SimpleSrc{
+					Name: "wodemingzi",
+					Age:  ekit.ToPtr(int(10)),
+				},
+				G: BasicSrc{
+					Name:    "nidemingzi",
+					Age:     23,
+					CNumber: complex(1, 2),
+				},
+			},
+		},
+		{
+			name: "dst 有额外字段 with ignore 2",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[DiffSrc, DiffDst]()
+				if err != nil {
+					return nil, err
+				}
+				dst := &DiffDst{
+					A: "66",
+					B: 1,
+					d: SimpleSrc{
+						Name: "wodemingzi",
+						Age:  ekit.ToPtr(int(10)),
+					},
+					G: BasicSrc{
+						Name:    "nidemingzi",
+						Age:     23,
+						CNumber: complex(1, 2),
+					},
+				}
+				err = copier.CopyTo(&DiffSrc{
+					A: "xiaowang",
+					B: 100,
+					c: SimpleSrc{
+						Name: "66",
+						Age:  ekit.ToPtr[int](100),
+					},
+					F: BasicSrc{
+						Name:    "good name",
+						Age:     200,
+						CNumber: complex(2, 2),
+					},
+				}, dst, IgnoreFields("G"))
+				return dst, err
+			},
+			wantDst: &DiffDst{
+				A: "xiaowang",
+				B: 100,
+				d: SimpleSrc{
+					Name: "wodemingzi",
+					Age:  ekit.ToPtr(int(10)),
+				},
+				G: BasicSrc{
+					Name:    "nidemingzi",
+					Age:     23,
+					CNumber: complex(1, 2),
+				},
+			},
+		},
+		{
+			name: "成员为结构体数组 with ignore",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[ArraySrc, ArrayDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&ArraySrc{
+					A: []SimpleSrc{
+						{
+							Name:    "大明",
+							Age:     ekit.ToPtr[int](18),
+							Friends: []string{"Tom", "Jerry"},
+						},
+						{
+							Name:    "小明",
+							Age:     ekit.ToPtr[int](8),
+							Friends: []string{"Tom"},
+						},
+					},
+				}, IgnoreFields("Age"))
+			},
+			wantDst: &ArrayDst{
+				A: []SimpleSrc{
+					{
+						Name:    "大明",
+						Age:     ekit.ToPtr[int](18),
+						Friends: []string{"Tom", "Jerry"},
+					},
+					{
+						Name:    "小明",
+						Age:     ekit.ToPtr[int](8),
+						Friends: []string{"Tom"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/bean/copier/reflect_copier_test.go
+++ b/bean/copier/reflect_copier_test.go
@@ -506,7 +506,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			wantDst: &SpecialDst2{A: 1},
 		},
 		{
-			name: "simple struct with ignore",
+			name: "simple_struct_忽略一个字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
 				if err != nil {
@@ -525,7 +525,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "simple struct with ignore 2",
+			name: "simple_struct_忽略多个字段_传入多个Option_每个Option传入一个字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
 				if err != nil {
@@ -544,7 +544,26 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "simple struct with ignore 3",
+			name: "simple_struct_忽略多个字段_传入一个Option_Option传入多个字段",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SimpleSrc{
+					Name:    "大明",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"Tom", "Jerry"},
+				}, IgnoreFields("Age", "Friends"))
+			},
+			wantDst: &SimpleDst{
+				Name:    "大明",
+				Age:     nil,
+				Friends: nil,
+			},
+		},
+		{
+			name: "simple_struct_忽略全部字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
 				if err != nil {
@@ -559,7 +578,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			wantDst: &SimpleDst{},
 		},
 		{
-			name: "simple struct 空切片, 空指针 with ignore",
+			name: "simple_struct_空切片_空指针_忽略字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
 				if err != nil {
@@ -574,40 +593,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "组合 struct with ignore",
-			copyFunc: func() (any, error) {
-				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
-				if err != nil {
-					return nil, err
-				}
-				return copier.Copy(&EmbedSrc{
-					SimpleSrc: SimpleSrc{
-						Name:    "xiaoli",
-						Age:     ekit.ToPtr[int](19),
-						Friends: []string{},
-					},
-					BasicSrc: &BasicSrc{
-						Name:    "xiaowang",
-						Age:     20,
-						CNumber: complex(2, 2),
-					},
-				}, IgnoreFields("Age"))
-			},
-			wantDst: &EmbedDst{
-				SimpleSrc: SimpleSrc{
-					Name:    "xiaoli",
-					Age:     nil,
-					Friends: []string{},
-				},
-				BasicSrc: &BasicSrc{
-					Name:    "xiaowang",
-					Age:     0,
-					CNumber: complex(2, 2),
-				},
-			},
-		},
-		{
-			name: "组合 struct with ignore 2",
+			name: "组合_struct_忽略组合中的一个字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
 				if err != nil {
@@ -640,7 +626,40 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "组合 struct with ignore 3",
+			name: "组合_struct_忽略组合中全部同名字段",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&EmbedSrc{
+					SimpleSrc: SimpleSrc{
+						Name:    "xiaoli",
+						Age:     ekit.ToPtr[int](19),
+						Friends: []string{},
+					},
+					BasicSrc: &BasicSrc{
+						Name:    "xiaowang",
+						Age:     20,
+						CNumber: complex(2, 2),
+					},
+				}, IgnoreFields("Age"))
+			},
+			wantDst: &EmbedDst{
+				SimpleSrc: SimpleSrc{
+					Name:    "xiaoli",
+					Age:     nil,
+					Friends: []string{},
+				},
+				BasicSrc: &BasicSrc{
+					Name:    "xiaowang",
+					Age:     0,
+					CNumber: complex(2, 2),
+				},
+			},
+		},
+		{
+			name: "组合_struct_忽略组合中同名结构体",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
 				if err != nil {
@@ -669,36 +688,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "组合 struct with ignore 4",
-			copyFunc: func() (any, error) {
-				copier, err := NewReflectCopier[EmbedSrc, EmbedDst]()
-				if err != nil {
-					return nil, err
-				}
-				return copier.Copy(&EmbedSrc{
-					SimpleSrc: SimpleSrc{
-						Name:    "xiaoli",
-						Age:     ekit.ToPtr[int](19),
-						Friends: []string{},
-					},
-					BasicSrc: &BasicSrc{
-						Name:    "xiaowang",
-						Age:     20,
-						CNumber: complex(2, 2),
-					},
-				}, IgnoreFields("BasicSrc"))
-			},
-			wantDst: &EmbedDst{
-				SimpleSrc: SimpleSrc{
-					Name:    "xiaoli",
-					Age:     ekit.ToPtr[int](19),
-					Friends: []string{},
-				},
-				BasicSrc: nil,
-			},
-		},
-		{
-			name: "复杂 Struct with ignore",
+			name: "复杂_Struct_忽略多层嵌套中全部同名字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
 				if err != nil {
@@ -755,7 +745,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "复杂 Struct with ignore 2",
+			name: "复杂_Struct_忽略多层嵌套中的同名结构体",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
 				if err != nil {
@@ -808,56 +798,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "复杂 Struct with ignore 3",
-			copyFunc: func() (any, error) {
-				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
-				if err != nil {
-					return nil, err
-				}
-				return copier.Copy(&ComplexSrc{
-					Simple: SimpleSrc{
-						Name:    "xiaohong",
-						Age:     ekit.ToPtr[int](18),
-						Friends: []string{"ha", "ha", "le"},
-					},
-					Embed: &EmbedSrc{
-						SimpleSrc: SimpleSrc{
-							Name:    "xiaopeng",
-							Age:     ekit.ToPtr[int](88),
-							Friends: []string{"la", "ha", "le"},
-						},
-						BasicSrc: &BasicSrc{
-							Name:    "wang",
-							Age:     22,
-							CNumber: complex(2, 1),
-						},
-					},
-					BasicSrc: BasicSrc{
-						Name:    "wang11",
-						Age:     22,
-						CNumber: complex(2, 1),
-					},
-				}, IgnoreFields("BasicSrc"))
-			},
-			wantDst: &ComplexDst{
-				Simple: SimpleDst{
-					Name:    "xiaohong",
-					Age:     ekit.ToPtr[int](18),
-					Friends: []string{"ha", "ha", "le"},
-				},
-				Embed: &EmbedDst{
-					SimpleSrc: SimpleSrc{
-						Name:    "xiaopeng",
-						Age:     ekit.ToPtr[int](88),
-						Friends: []string{"la", "ha", "le"},
-					},
-					BasicSrc: nil,
-				},
-				BasicSrc: BasicSrc{},
-			},
-		},
-		{
-			name: "复杂 Struct with ignore 4",
+			name: "复杂_Struct_忽略多层嵌套中的整个结构体",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[ComplexSrc, ComplexDst]()
 				if err != nil {
@@ -903,7 +844,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "特殊类型 with ignore",
+			name: "特殊类型_忽略结构体中的切片",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[SpecialSrc, SpecialDst]()
 				if err != nil {
@@ -926,7 +867,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "特殊类型 with ignore 2",
+			name: "特殊类型_忽略结构体中的map",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[SpecialSrc, SpecialDst]()
 				if err != nil {
@@ -946,7 +887,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "dst 有额外字段 with ignore",
+			name: "dst_有额外字段_忽略一个字段_其他字段会被赋值",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[DiffSrc, DiffDst]()
 				if err != nil {
@@ -995,7 +936,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "dst 有额外字段 with ignore 2",
+			name: "dst_有额外字段_不会忽略dst的字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[DiffSrc, DiffDst]()
 				if err != nil {
@@ -1044,7 +985,7 @@ func TestReflectCopier_Copy(t *testing.T) {
 			},
 		},
 		{
-			name: "成员为结构体数组 with ignore",
+			name: "成员为结构体数组_不会忽略结构体中的字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[ArraySrc, ArrayDst]()
 				if err != nil {

--- a/bean/copier/reflect_copier_test.go
+++ b/bean/copier/reflect_copier_test.go
@@ -506,6 +506,25 @@ func TestReflectCopier_Copy(t *testing.T) {
 			wantDst: &SpecialDst2{A: 1},
 		},
 		{
+			name: "simple_struct_忽略字段的时候传空",
+			copyFunc: func() (any, error) {
+				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()
+				if err != nil {
+					return nil, err
+				}
+				return copier.Copy(&SimpleSrc{
+					Name:    "大明",
+					Age:     ekit.ToPtr[int](18),
+					Friends: []string{"Tom", "Jerry"},
+				}, IgnoreFields())
+			},
+			wantDst: &SimpleDst{
+				Name:    "大明",
+				Age:     ekit.ToPtr[int](18),
+				Friends: []string{"Tom", "Jerry"},
+			},
+		},
+		{
 			name: "simple_struct_忽略一个字段",
 			copyFunc: func() (any, error) {
 				copier, err := NewReflectCopier[SimpleSrc, SimpleDst]()


### PR DESCRIPTION
我直接采用了可行方案，引入 options 结构体。

需要忽略的字段需要有个地方存储，我想过直接把需要忽略的字段加在方法后面，但这显然不是个好主意。如果后续又有其他的附加功能，那这种设计就要继续在方法后面加参数。

引入 options 结构体后，在调用方法的时候，可以使用 option 设计模式，自主决定需要怎么修改 options 结构体的参数（触发哪些附加功能）。

忽略字段的逻辑，安排在了拷贝结点的过程中，如果发现结构体的属性名在需要忽略的字段里，就跳过这个属性的拷贝。

我把之前的差不多每个有效情况的测试用例都复制了一份，添加了一些忽略字段的场景。
