### PR TITLE
重构: syncx: map

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -11,6 +11,7 @@
 - [mapx: 为 MultipleMap 添加 PutVals 方法](https://github.com/ecodeclub/ekit/pull/189)
 - [mapx: LinkedMap 特性](https://github.com/ecodeclub/ekit/pull/191)
 - [copier: ReflectCopier 支持忽略字段](https://github.com/ecodeclub/ekit/pull/196)
+- [syncx: 重构LoadOrStoreFunc方法及相关测试](https://github.com/ecodeclub/ekit/pull/198)
 
 # v0.0.7
 - [slice: FilterDelete](https://github.com/ecodeclub/ekit/pull/152)

--- a/syncx/map.go
+++ b/syncx/map.go
@@ -56,7 +56,6 @@ func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
 // 它的代价就是 Key 不存在的时候会多一次 Load 调用。
 // 当 fn 返回 error 的时候，LoadOrStoreFunc 也会返回 error。
 func (m *Map[K, V]) LoadOrStoreFunc(key K, fn func() (V, error)) (actual V, loaded bool, err error) {
-	var anyVal any
 	val, ok := m.Load(key)
 	if ok {
 		return val, true, nil
@@ -65,10 +64,7 @@ func (m *Map[K, V]) LoadOrStoreFunc(key K, fn func() (V, error)) (actual V, load
 	if err != nil {
 		return
 	}
-	anyVal, loaded = m.m.LoadOrStore(key, val)
-	if anyVal != nil {
-		actual = anyVal.(V)
-	}
+	actual, loaded = m.LoadOrStore(key, val)
 	return
 }
 


### PR DESCRIPTION
- [x] LoadOrStoreFunc直接调用map自身的LoadOrStore,消除重复
- [x] 使用子测试增力测试,某些断言使用Same方法替代Equal明确意图——map中放入与取出的指针类型应该指向同一个内存对象/内存地址,而不是不同地址内存对象但内容相同