### PR TITLE
[feat](stringx) 新增unsafe 转换 string 和 []byte

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -24,7 +24,7 @@
 - [sqlx: 修复EncryptColumn Scan方法string分支错误](https://github.com/ecodeclub/ekit/pull/211)
 - [sqlx: Scanner 添加 NextResultSet 方法](https://github.com/ecodeclub/ekit/pull/212)
 - [ekit: AnyValue 支持As[Type]类型 String 转换](https://github.com/ecodeclub/ekit/pull/213)
-
+- [stringx: unsafe 转换 string 和 []byte](https://github.com/ecodeclub/ekit/pull/215)
 
 # v0.0.7
 - [slice: FilterDelete](https://github.com/ecodeclub/ekit/pull/152)

--- a/stringx/string.go
+++ b/stringx/string.go
@@ -1,0 +1,37 @@
+// Copyright 2021 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stringx
+
+import (
+	"unsafe"
+)
+
+// 确保传入的字符串和字节切片的生命周期足够长，不会在转换后被释放或修改。
+// 确保传入的字符串和字节切片的长度和容量是一致的，否则可能导致访问越界。
+// 不要对转换后的字节切片或字符串进行修改，因为它们可能与原始的字符串或字节切片共享底层的内存。
+
+// UnsafeToBytes 非安全 string 转 []byte 他必须遵守上述规则
+func UnsafeToBytes(val string) []byte {
+	sh := (*[2]uintptr)(unsafe.Pointer(&val))
+	bh := [3]uintptr{sh[0], sh[1], sh[1]}
+	return *(*[]byte)(unsafe.Pointer(&bh))
+}
+
+// UnsafeToString 非安全 []byte 转 string 他必须遵守上述规则
+func UnsafeToString(val []byte) string {
+	bh := (*[3]uintptr)(unsafe.Pointer(&val))
+	sh := [2]uintptr{bh[0], bh[1]}
+	return *(*string)(unsafe.Pointer(&sh))
+}

--- a/stringx/string_test.go
+++ b/stringx/string_test.go
@@ -1,0 +1,126 @@
+// Copyright 2021 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stringx
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnsafeToBytes(t *testing.T) {
+	testCase := []struct {
+		name string
+		val  string
+		want []byte
+	}{
+		{
+			name: "normal conversion",
+			val:  "hello",
+			want: []byte("hello"),
+		},
+		{
+			name: "emoji coversion",
+			val:  "😀!hello world",
+			want: []byte("😀!hello world"),
+		},
+		{
+			name: "chinese coversion",
+			val:  "你好 世界！",
+			want: []byte("你好 世界！"),
+		},
+	}
+
+	for _, tt := range testCase {
+		t.Run(tt.name, func(t *testing.T) {
+			val := UnsafeToBytes(tt.val)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func TestUnsafeToString(t *testing.T) {
+	testCase := []struct {
+		name   string
+		before func(t *testing.T)
+		after  func(t *testing.T)
+		val    func(t *testing.T) []byte
+		want   string
+	}{
+		{
+			name:   "normal conversion",
+			before: func(t *testing.T) {},
+			after:  func(t *testing.T) {},
+			val: func(t *testing.T) []byte {
+				return []byte("hello")
+			},
+			want: "hello",
+		},
+		{
+			name:   "emoji coversion",
+			before: func(t *testing.T) {},
+			after:  func(t *testing.T) {},
+			val: func(t *testing.T) []byte {
+				return []byte("😀!hello world")
+			},
+			want: "😀!hello world",
+		},
+		{
+			name:   "chinese coversion",
+			before: func(t *testing.T) {},
+			after:  func(t *testing.T) {},
+			val: func(t *testing.T) []byte {
+				return []byte("你好 世界！")
+			},
+			want: "你好 世界！",
+		},
+		{
+			name: "file io.Reader coversion",
+			before: func(t *testing.T) {
+				create, err := os.Create("test_put.txt")
+				require.NoError(t, err)
+				defer create.Close()
+				_, err = create.WriteString("the test file...")
+				require.NoError(t, err)
+			},
+			after: func(t *testing.T) {
+				require.NoError(t, os.Remove("test_put.txt"))
+			},
+			val: func(t *testing.T) []byte {
+				open, err := os.Open("test_put.txt")
+				require.NoError(t, err)
+				defer open.Close()
+				buf := bytes.Buffer{}
+				_, err = buf.ReadFrom(open)
+				require.NoError(t, err)
+				return buf.Bytes()
+			},
+			want: "the test file...",
+		},
+	}
+
+	for _, tt := range testCase {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.before(t)
+			b := tt.val(t)
+			val := UnsafeToString(b)
+			assert.Equal(t, tt.want, val)
+			tt.after(t)
+		})
+	}
+}

--- a/stringx/string_test.go
+++ b/stringx/string_test.go
@@ -90,19 +90,21 @@ func TestUnsafeToString(t *testing.T) {
 			want: "你好 世界！",
 		},
 		{
-			name: "file io.Reader coversion",
+			// 通过读取 file 文件 模拟 io.Reader 中存在的字节流 并将其转换为 string 检查他的正确性
+			// 当然他必须是可控制的
+			name: "file(io.Reader) read bytes stream coversion string",
 			before: func(t *testing.T) {
-				create, err := os.Create("test_put.txt")
+				create, err := os.Create("/tmp/test_put.txt")
 				require.NoError(t, err)
 				defer create.Close()
 				_, err = create.WriteString("the test file...")
 				require.NoError(t, err)
 			},
 			after: func(t *testing.T) {
-				require.NoError(t, os.Remove("test_put.txt"))
+				require.NoError(t, os.Remove("/tmp/test_put.txt"))
 			},
 			val: func(t *testing.T) []byte {
-				open, err := os.Open("test_put.txt")
+				open, err := os.Open("/tmp/test_put.txt")
 				require.NoError(t, err)
 				defer open.Close()
 				buf := bytes.Buffer{}
@@ -116,11 +118,11 @@ func TestUnsafeToString(t *testing.T) {
 
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
+			defer tt.after(t)
 			tt.before(t)
 			b := tt.val(t)
 			val := UnsafeToString(b)
 			assert.Equal(t, tt.want, val)
-			tt.after(t)
 		})
 	}
 }


### PR DESCRIPTION
Closes #214 
注意使用非安全的方式转换时一定要注意以下三点
- 确保传入的字符串和字节切片的生命周期足够长，不会在转换后被释放或修改。
- 确保传入的字符串和字节切片的长度和容量是一致的，否则可能导致访问越界。
- 不要对转换后的字节切片或字符串进行修改，因为它们可能与原始的字符串或字节切片共享底层的内存。