### PR TITLE
queue: 暴露超出容量错误

### DIFF
--- a/queue/errs.go
+++ b/queue/errs.go
@@ -1,0 +1,20 @@
+// Copyright 2021 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import "github.com/ecodeclub/ekit/internal/queue"
+
+// ErrOutOfCapacity 超过容量
+var ErrOutOfCapacity = queue.ErrOutOfCapacity


### PR DESCRIPTION
当我需要一个固定容量的队列，并且希望在队列满了之后淘汰掉优先级最低的元素的时候，我就需要知道这个错误。