### PR TITLE
[WIP]尝试给list加Iter

### DIFF
--- a/internal/errs/error.go
+++ b/internal/errs/error.go
@@ -36,3 +36,5 @@ func NewErrInvalidIntervalValue(interval time.Duration) error {
 func NewErrInvalidMaxIntervalValue(maxInterval, initialInterval time.Duration) error {
 	return fmt.Errorf("ekit: 最大重试间隔的时间 [%d] 应大于等于初始重试的间隔时间 [%d] ", maxInterval, initialInterval)
 }
+
+var ErrNotEditableDuringIterating error = fmt.Errorf("ekit: List在有Iterator工作期间不可被编辑")

--- a/list/iterable_list.go
+++ b/list/iterable_list.go
@@ -1,0 +1,101 @@
+package list
+
+import (
+	"strings"
+
+	"github.com/ecodeclub/ekit/internal/errs"
+)
+
+type IterableListImpl[T any] struct {
+	List[T]
+	hasIter bool
+}
+
+func NewIterableList[T any](list List[T]) *IterableListImpl[T] {
+	return &IterableListImpl[T]{
+		List: list,
+	}
+}
+
+func (l *IterableListImpl[T]) GetIter() (Iter[T], bool) {
+	if l.hasIter {
+		return nil, false
+	}
+	l.hasIter = true
+	return &IterImpl[T]{
+		iterableList:   l,
+		index:          -1,
+		deletedIndices: make([]int, 0, 4),
+	}, true
+}
+
+func (l *IterableListImpl[T]) releaseIter(f func(list List[T])) {
+	l.hasIter = false
+	f(l.List)
+}
+
+func (l *IterableListImpl[T]) Add(index int, t T) error {
+	if l.hasIter {
+		return errs.ErrNotEditableDuringIterating
+	}
+	return l.List.Add(index, t)
+}
+
+func (l *IterableListImpl[T]) Delete(index int) (T, error) {
+	if l.hasIter {
+		var empty T
+		return empty, errs.ErrNotEditableDuringIterating
+	}
+	return l.List.Delete(index)
+}
+
+type IterImpl[T any] struct {
+	iterableList   IterableList[T]
+	index          int
+	deletedIndices []int
+}
+
+func (i *IterImpl[T]) Next() (T, bool) {
+	if i.index >= i.iterableList.Len() {
+		var empty T
+		return empty, false
+	}
+	i.index++
+	ele, err := i.iterableList.Get(i.index)
+	if err != nil {
+		if !strings.HasPrefix(err.Error(), "ekit: 下标超出范围") {
+			panic(err)
+		}
+		// 释放Iter
+		i.iterableList.releaseIter(i.doDelete)
+		var empty T
+		return empty, false
+	}
+	return ele, true
+}
+
+func (i *IterImpl[T]) Delete() {
+	if i.index < 0 || i.index >= i.iterableList.Len() {
+		return
+	}
+	i.deletedIndices = append(i.deletedIndices, i.index)
+}
+
+func (i *IterImpl[T]) Release() {
+	i.iterableList.releaseIter(i.doDelete)
+	i.index = i.iterableList.Len()
+}
+
+func (i *IterImpl[T]) doDelete(l List[T]) {
+	prev := -1
+	for j := len(i.deletedIndices) - 1; j >= 0; j-- {
+		idx := i.deletedIndices[j]
+		if idx != prev {
+			if _, err := l.Delete(idx); err != nil {
+				panic(err)
+			}
+			prev = idx
+		}
+	}
+	i.deletedIndices = nil
+}

--- a/list/iterable_list_test.go
+++ b/list/iterable_list_test.go
@@ -1,0 +1,176 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIterableList_IterNext(t *testing.T) {
+	testCase := struct {
+		name      string
+		list      IterableList[int]
+		wantSlice []int
+	}{
+		name:      "range the list",
+		list:      NewIterableList[int](NewArrayListOf([]int{1, 2, 3})),
+		wantSlice: []int{1, 2, 3},
+	}
+	t.Run(testCase.name, func(t *testing.T) {
+		iter, ok := testCase.list.GetIter()
+		assert.Equal(t, true, ok)
+		slice := make([]int, 0, testCase.list.Len())
+		for {
+			ele, ok := iter.Next()
+			if !ok {
+				break
+			}
+			slice = append(slice, ele)
+		}
+		assert.Equal(t, testCase.wantSlice, slice)
+	})
+}
+
+func TestIterableList_DuplicatedIter(t *testing.T) {
+	testCase := struct {
+		name string
+		list IterableList[int]
+	}{
+		name: "range the list",
+		list: NewIterableList[int](NewArrayListOf([]int{1, 2, 3})),
+	}
+	t.Run(testCase.name, func(t *testing.T) {
+		iter, ok := testCase.list.GetIter()
+		assert.Equal(t, true, ok)
+		_, ok = testCase.list.GetIter()
+		assert.Equal(t, false, ok)
+		for {
+			_, ok := iter.Next()
+			if !ok {
+				break
+			}
+		}
+		iter, ok = testCase.list.GetIter()
+		assert.Equal(t, true, ok)
+	})
+}
+
+func TestIterableList_ModifyDuringIterating(t *testing.T) {
+	testCase := struct {
+		name       string
+		list       IterableList[int]
+		wantSlice1 []int
+		wantSlice2 []int
+	}{
+		name:       "range the list",
+		list:       NewIterableList[int](NewArrayListOf([]int{1, 2, 3})),
+		wantSlice1: []int{1, 2, 3},
+		wantSlice2: []int{4, 1, 2, 3},
+	}
+	t.Run(testCase.name, func(t *testing.T) {
+		iter, ok := testCase.list.GetIter()
+		assert.Equal(t, true, ok)
+		err := testCase.list.Add(0, 4)
+		assert.Equal(t, true, err != nil)
+		slice := make([]int, 0, testCase.list.Len())
+		for {
+			ele, ok := iter.Next()
+			if !ok {
+				break
+			}
+			slice = append(slice, ele)
+		}
+		assert.Equal(t, testCase.wantSlice1, slice)
+		err = testCase.list.Add(0, 4)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, testCase.wantSlice2, testCase.list.AsSlice())
+	})
+}
+
+func TestIterableList_IterRelease(t *testing.T) {
+	testCase := struct {
+		name       string
+		list       IterableList[int]
+		wantSlice1 []int
+		wantSlice2 []int
+		wantSlice3 []int
+	}{
+		name:       "range the list",
+		list:       NewIterableList[int](NewArrayListOf([]int{1, 2, 3})),
+		wantSlice1: []int{1, 2, 3},
+		wantSlice2: []int{4, 1, 2, 3},
+		wantSlice3: []int{4, 2, 3},
+	}
+	t.Run(testCase.name, func(t *testing.T) {
+		iter, ok := testCase.list.GetIter()
+		assert.Equal(t, true, ok)
+		err := testCase.list.Add(0, 4)
+		assert.Equal(t, true, err != nil)
+		_, err = testCase.list.Delete(0)
+		assert.Equal(t, true, err != nil)
+		iter.Release()
+		assert.Equal(t, testCase.wantSlice1, testCase.list.AsSlice())
+		err = testCase.list.Add(0, 4)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, testCase.wantSlice2, testCase.list.AsSlice())
+		_, err2 := testCase.list.Delete(1)
+		assert.Equal(t, nil, err2)
+		assert.Equal(t, testCase.wantSlice3, testCase.list.AsSlice())
+		iter.Release() // Release again
+		assert.Equal(t, testCase.wantSlice3, testCase.list.AsSlice())
+	})
+}
+
+func TestIterableList_IterDelete(t *testing.T) {
+	testCase := struct {
+		name      string
+		list      IterableList[int]
+		wantSlice []int
+	}{
+		name:      "range the list",
+		list:      NewIterableList[int](NewArrayListOf([]int{1, 2, 3, 4})),
+		wantSlice: []int{2, 4},
+	}
+	t.Run(testCase.name, func(t *testing.T) {
+		iter, ok := testCase.list.GetIter()
+		assert.Equal(t, true, ok)
+		for {
+			ele, ok := iter.Next()
+			if !ok {
+				break
+			}
+			if ele&1 == 1 {
+				iter.Delete()
+				iter.Delete()
+			}
+		}
+		assert.Equal(t, testCase.wantSlice, testCase.list.AsSlice())
+	})
+}
+
+func TestIterableList_IterDeleteAndRelease(t *testing.T) {
+	testCase := struct {
+		name      string
+		list      IterableList[int]
+		wantSlice []int
+	}{
+		name:      "range the list",
+		list:      NewIterableList[int](NewArrayListOf([]int{1, 2, 3, 4})),
+		wantSlice: []int{2, 3, 4},
+	}
+	t.Run(testCase.name, func(t *testing.T) {
+		iter, ok := testCase.list.GetIter()
+		assert.Equal(t, true, ok)
+		for i := 0; i < testCase.list.Len()>>1; i++ {
+			ele, ok := iter.Next()
+			if !ok {
+				break
+			}
+			if ele&1 == 1 {
+				iter.Delete()
+			}
+		}
+		iter.Release()
+		assert.Equal(t, testCase.wantSlice, testCase.list.AsSlice())
+	})
+}

--- a/list/types.go
+++ b/list/types.go
@@ -43,3 +43,16 @@ type List[T any] interface {
 	// AsSlice 每次调用都必须返回一个全新的切片
 	AsSlice() []T
 }
+
+// IterableList List仅在没有Iter时可被编辑，一个Iter只能有一个Iter
+type IterableList[T any] interface {
+	List[T]
+	GetIter() (Iter[T], bool)
+	releaseIter(func(list List[T]))
+}
+
+type Iter[T any] interface {
+	Next() (T, bool)
+	Delete()
+	Release()
+}


### PR DESCRIPTION
尝试给list加一个iterater，写了一个demo
用装饰器模式，在原有list接口上设计IterableList与Iter接口
一个IterableList最多拥有一个Iter，有Iter时候IterableList不许Add和Delete，其余写操作不禁止
Iter实现Delete方法时，采用懒删除的策略，Iter.Delete只是把对应的index放入deleteIndices数组中；在Iter.Next为空时，或用户主动Release这个Iter时，执行之前累积的的所有删除操作