### PR TITLE
提交迭代器及数组的实现

### DIFF
--- a/internal/iterator/types.go
+++ b/internal/iterator/types.go
@@ -1,0 +1,58 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import "errors"
+
+var (
+	ErrStructHasChange = errors.New("ekit: 迭代器内元素已经被修改")
+	ErrNoSuchData      = errors.New("ekit:没有找到当前元素")
+)
+
+// Iterator 一个迭代器的接口，所有的容器类型都可以实现自己的迭代器,只需要继承当前接口即可
+type Iterator[T any] interface {
+	// Next 迭代器移动到下一个节点，并且返回当前指向的节点
+	// 如果没有下一个节点，返回nil 和err
+	Next() (T, error)
+
+	// Get 获取迭代器当前所指向的节点的信息
+	Get() (T, error)
+
+	// HasNext 判断是否有后继节点
+	HasNext() bool
+
+	//// Valid 判断当前节点是否合法
+	//Valid() bool
+	// Err 主要是在 HasNext后获取错误
+	Err() error
+
+	// Delete 删除当前节点
+	Delete() error
+}
+
+// IteratorAble Iterator的标记接口
+type IteratorAble[T any] interface {
+	Iterator() *Iterator[T]
+}
+
+// ModCount 修改计数
+type ModCount interface {
+	GetModCount() int
+	Increment()
+}
+
+// UnModInRange 由于有的数据结构支持迭代器遍历的时候进行删除或者修改，所以单独设计了一个接口
+type UnModInRange[T any] interface {
+	CheckMod() error
+}

--- a/list/array_list_iter_test.go
+++ b/list/array_list_iter_test.go
@@ -1,0 +1,269 @@
+// Copyright 2021 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"github.com/ecodeclub/ekit/internal/iterator"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArrayList_Iter_range(t *testing.T) {
+	testCases := []struct {
+		name      string
+		list      *ArrayList[int]
+		index     int
+		wantSlice []int
+		wantErr   error
+	}{
+		{
+			name:      "遍历数组",
+			list:      NewArrayListOf[int]([]int{1, 2, 3}),
+			wantSlice: []int{1, 2, 3},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//err := tc.list.Add(tc.index, tc.newVal)
+			iter := tc.list.Iterator()
+			// 这里处理error 很恶心
+			ints := make([]int, 0, tc.list.Len())
+			var err error
+			for iter.HasNext() {
+				next, err := iter.Next()
+				assert.NoError(t, err)
+				ints = append(ints, next)
+			}
+			assert.Equal(t, tc.wantErr, err)
+			// 因为返回了 error，所以我们不用继续往下比较了
+			if err != nil {
+				return
+			}
+			assert.Equal(t, tc.wantSlice, ints)
+		})
+	}
+}
+
+func TestArrayList_Iter_delete(t *testing.T) {
+	testCases := []struct {
+		name      string
+		list      *ArrayList[int]
+		index     int
+		fn        func(ite iterator.Iterator[int]) error
+		wantSlice []int
+		wantErr   error
+	}{
+		{
+			name:  "删除某个元素",
+			list:  NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			index: 3,
+			fn: func(ite iterator.Iterator[int]) error {
+				err := ite.Delete()
+				if err != nil {
+					return err
+				}
+				if ite.HasNext() {
+					_, err := ite.Next()
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			wantSlice: []int{1, 2, 4, 5},
+		},
+		{
+			name:  "连续删除元素",
+			list:  NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			index: 3,
+			fn: func(ite iterator.Iterator[int]) error {
+				err := ite.Delete()
+				if err != nil {
+					return err
+				}
+				err = ite.Delete()
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+			wantErr: iterator.ErrNoSuchData,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//err := tc.list.Add(tc.index, tc.newVal)
+			iter := tc.list.Iterator()
+			// 这里处理error 很恶心
+			ints := make([]int, 0, tc.list.Len())
+			var i = 1
+			var err error
+			for iter.HasNext() {
+				next, err := iter.Next()
+				i++
+				if i == tc.index {
+					err = tc.fn(iter)
+					if err != nil {
+						return
+					}
+				}
+
+				ints = append(ints, next)
+
+			}
+			assert.Equal(t, tc.wantErr, err)
+			// 因为返回了 error，所以我们不用继续往下比较了
+			if err != nil {
+				return
+			}
+			assert.NoError(t, iter.Err())
+			assert.Equal(t, tc.wantSlice, ints)
+		})
+	}
+}
+
+func TestArrayList_Iter_get(t *testing.T) {
+	testCases := []struct {
+		name      string
+		list      *ArrayList[int]
+		wantSlice []int
+		wantErr   error
+	}{
+		{
+			name:      "获取当前节点",
+			list:      NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			wantSlice: []int{1, 2, 3, 4, 5},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//err := tc.list.Add(tc.index, tc.newVal)
+			iter := tc.list.Iterator()
+			// 这里处理error 很恶心
+			ints := make([]int, 0, tc.list.Len())
+			var err error
+			for iter.HasNext() {
+				get, err := iter.Get()
+
+				ints = append(ints, get)
+				_, err = iter.Next()
+				assert.NoError(t, err)
+
+			}
+			assert.Equal(t, tc.wantErr, err)
+			// 因为返回了 error，所以我们不用继续往下比较了
+			if err != nil {
+				return
+			}
+			assert.NoError(t, iter.Err())
+			assert.Equal(t, tc.wantSlice, ints)
+		})
+	}
+}
+
+func TestArrayList_Iter_mod(t *testing.T) {
+	testCases := []struct {
+		name    string
+		list    *ArrayList[int]
+		index   int
+		fn      func(l *ArrayList[int], idx int) error
+		wantErr error
+	}{
+		{
+			name:  "在迭代的时候进行追加元素",
+			list:  NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			index: 3,
+			fn: func(l *ArrayList[int], idx int) error {
+				err := l.Append(0)
+				return err
+			},
+			wantErr: iterator.ErrStructHasChange,
+		},
+		{
+			name:  "在迭代的时候进行新增数组",
+			list:  NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			index: 3,
+			fn: func(l *ArrayList[int], idx int) error {
+				err := l.Add(idx, 0)
+				return err
+			},
+			wantErr: iterator.ErrStructHasChange,
+		},
+		{
+			name:  "在迭代的时候进行设置数组",
+			list:  NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			index: 3,
+			fn: func(l *ArrayList[int], idx int) error {
+				err := l.Set(idx, 0)
+				return err
+			},
+			wantErr: iterator.ErrStructHasChange,
+		},
+		{
+			name:  "在迭代的时候进行删除数组",
+			list:  NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			index: 3,
+			fn: func(l *ArrayList[int], idx int) error {
+				_, err := l.Delete(idx)
+				return err
+			},
+			wantErr: iterator.ErrStructHasChange,
+		},
+
+		{
+			name:  "在迭代的时候进行缩容",
+			list:  NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+			index: 3,
+			fn: func(l *ArrayList[int], idx int) error {
+				l.shrink()
+				return nil
+			},
+			wantErr: iterator.ErrStructHasChange,
+		},
+
+		{
+			name: "在迭代的时候不进行修改",
+			list: NewArrayListOf[int]([]int{1, 2, 3, 4, 5}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//err := tc.list.Add(tc.index, tc.newVal)
+			iter := tc.list.Iterator()
+			var i = 1
+			// 这里处理error 很恶心
+			var err error
+			for iter.HasNext() {
+				_, err = iter.Next()
+				assert.NoError(t, err)
+				i++
+				if i == tc.index {
+					err := tc.fn(tc.list, tc.index)
+					assert.NoError(t, err)
+				}
+			}
+			assert.Equal(t, tc.wantErr, iter.Err())
+			// 因为返回了 error，所以我们不用继续往下比较了
+			if err != nil {
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
创建了一个初步的实现，
迭代器这种工具由于是遍历，所以删除指支持到了删除当前元素。
然后接口设计的error，我觉得hasNext的方法如果返回error，用起来很麻烦，所以加了一个Err()，但是感觉很冗余
对于是否支持在迭代的时候修改元素，本质上还是一个冲突问题。
迭代器本质上关心的还是把元素给取出来遍历，如果需要在迭代器里面对原数据结构修改，我觉得应该是要对不同的数据结构进类型单独设计迭代器方法，而不是放到顶层接口中，如果在迭代的时候如果对原来的数据结构进行了修改，会导致数据不一致问题，结果很难预知，调用者也很难处理。我觉得这个时候应该需要终止迭代器，然后重新获取数组元素。
