### PR TITLE
添加 `IfThenElse` 函数返回泛型结果

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -14,11 +14,19 @@
 
 package ekit
 
-// IfThenElse 根据条件返回对应的泛型结果，请注意，结果值在传入时就会访问，请务必确认其合法性
-// 例：传 trueValue 时传入了一个指针对象并调用其方法，需要先判空
+// IfThenElse 根据条件返回对应的泛型结果
+// 注意避免结果的空指针问题
 func IfThenElse[T any](condition bool, trueValue, falseValue T) T {
 	if condition {
 		return trueValue
 	}
 	return falseValue
+}
+
+// IfThenElseFunc 根据条件执行对应的函数并返回泛型结果
+func IfThenElseFunc[T any](condition bool, trueFunc, falseFunc func() T) T {
+	if condition {
+		return trueFunc()
+	}
+	return falseFunc()
 }

--- a/condition.go
+++ b/condition.go
@@ -24,7 +24,7 @@ func IfThenElse[T any](condition bool, trueValue, falseValue T) T {
 }
 
 // IfThenElseFunc 根据条件执行对应的函数并返回泛型结果
-func IfThenElseFunc[T any](condition bool, trueFunc, falseFunc func() T) T {
+func IfThenElseFunc[T any](condition bool, trueFunc, falseFunc func() (T, error)) (T, error) {
 	if condition {
 		return trueFunc()
 	}

--- a/condition.go
+++ b/condition.go
@@ -1,0 +1,24 @@
+// Copyright 2021 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ekit
+
+// IfThenElse 根据条件返回对应的泛型结果，请注意，结果值在传入时就会访问，请务必确认其合法性
+// 例：传 trueValue 时传入了一个指针对象并调用其方法，需要先判空
+func IfThenElse[T any](condition bool, trueValue, falseValue T) T {
+	if condition {
+		return trueValue
+	}
+	return falseValue
+}

--- a/condition_test.go
+++ b/condition_test.go
@@ -15,8 +15,9 @@
 package ekit
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIfThenElse(t *testing.T) {

--- a/condition_test.go
+++ b/condition_test.go
@@ -37,26 +37,29 @@ func ExampleIfThenElse() {
 }
 
 func TestIfThenElseFunc(t *testing.T) {
-	err := IfThenElseFunc(true, func() error {
-		return nil
-	}, func() error {
-		return errors.New("some error")
+	resp, err := IfThenElseFunc(true, func() (int, error) {
+		return 0, nil
+	}, func() (int, error) {
+		return 1, errors.New("some error")
 	})
 	assert.NoError(t, err)
+	assert.Equal(t, resp, 0)
 }
 
 func ExampleIfThenElseFunc() {
-	err := IfThenElseFunc(false, func() error {
+	code, err := IfThenElseFunc(false, func() (code int, err error) {
 		// do something when condition is true
 		// ...
-		return nil
-	}, func() error {
+		return 0, nil
+	}, func() (code int, err error) {
 		// do something when condition is false
 		// ...
-		return errors.New("some error when execute func2")
+		return 1, errors.New("some error when execute func2")
 	})
+	fmt.Println(code)
 	fmt.Println(err)
 
 	// Output:
+	// 1
 	// some error when execute func2
 }

--- a/condition_test.go
+++ b/condition_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 ecodeclub
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ekit
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIfThenElse(t *testing.T) {
+	i := 7
+	i = IfThenElse(false, i, 0)
+	assert.Equal(t, i, 0)
+}

--- a/condition_test.go
+++ b/condition_test.go
@@ -15,6 +15,8 @@
 package ekit
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +26,37 @@ func TestIfThenElse(t *testing.T) {
 	i := 7
 	i = IfThenElse(false, i, 0)
 	assert.Equal(t, i, 0)
+}
+
+func ExampleIfThenElse() {
+	result := IfThenElse(true, "yes", "no")
+	fmt.Println(result)
+
+	// Output:
+	// yes
+}
+
+func TestIfThenElseFunc(t *testing.T) {
+	err := IfThenElseFunc(true, func() error {
+		return nil
+	}, func() error {
+		return errors.New("some error")
+	})
+	assert.NoError(t, err)
+}
+
+func ExampleIfThenElseFunc() {
+	err := IfThenElseFunc(false, func() error {
+		// do something when condition is true
+		// ...
+		return nil
+	}, func() error {
+		// do something when condition is false
+		// ...
+		return errors.New("some error when execute func2")
+	})
+	fmt.Println(err)
+
+	// Output:
+	// some error when execute func2
 }


### PR DESCRIPTION
### 添加 IfThenElse 函数

此 PR 添加了一个 `IfThenElse` 函数，它根据条件返回对应的泛型结果。该函数允许在单行代码中实现类似三元运算符的功能。

#### 功能概述:
- `IfThenElse[T any](condition bool, trueValue, falseValue T) T` 根据布尔条件返回 `trueValue` 或 `falseValue`。
- 支持泛型，能够处理任意类型的输入。
- 请注意，`trueValue` 和 `falseValue` 在传入时即会访问，因此调用方需确保它们的合法性。

#### 示例:
```go
result := IfThenElse(true, "Success", "Failure")
fmt.Println(result) // 输出: Success
