### PR TITLE
优化Add内存分配及执行效率

### DIFF
--- a/internal/slice/add.go
+++ b/internal/slice/add.go
@@ -14,7 +14,9 @@
 
 package slice
 
-import "github.com/ecodeclub/ekit/internal/errs"
+import (
+	"github.com/ecodeclub/ekit/internal/errs"
+)
 
 func Add[T any](src []T, element T, index int) ([]T, error) {
 	length := len(src)
@@ -22,14 +24,18 @@ func Add[T any](src []T, element T, index int) ([]T, error) {
 		return nil, errs.NewErrIndexOutOfRange(length, index)
 	}
 
-	//先将src扩展一个元素
-	var zeroValue T
-	src = append(src, zeroValue)
-	for i := len(src) - 1; i > index; i-- {
-		if i-1 >= 0 {
-			src[i] = src[i-1]
-		}
-	}
-	src[index] = element
+	valtmp := make([]T, length+1)
+	// 复制 index 之前的元素
+	copy(valtmp, src[:index])
+
+	// 插入新元素
+	valtmp[index] = element
+
+	// 复制 index 之后的元素
+	copy(valtmp[index+1:], src[index:])
+
+	// 更新原切片
+	src = valtmp
+
 	return src, nil
 }

--- a/internal/slice/add_test.go
+++ b/internal/slice/add_test.go
@@ -90,3 +90,39 @@ func TestAdd(t *testing.T) {
 		})
 	}
 }
+
+func OldAdd[T any](src []T, element T, index int) ([]T, error) {
+	length := len(src)
+	if index < 0 || index > length {
+		return nil, errs.NewErrIndexOutOfRange(length, index)
+	}
+
+	//先将src扩展一个元素
+	var zeroValue T
+	src = append(src, zeroValue)
+	for i := len(src) - 1; i > index; i-- {
+		if i-1 >= 0 {
+			src[i] = src[i-1]
+		}
+	}
+	src[index] = element
+	return src, nil
+}
+
+func Benchmark_Add(b *testing.B) {
+
+	vals := []int{1, 5, 6, 3, 7}
+
+	b.Run("Newadd", func(b *testing.B) {
+		b.ReportAllocs() // 开启内存分配报告
+		for i := 0; i < b.N; i++ {
+			Add(vals, 785, 3)
+		}
+	})
+	b.Run("Oldadd", func(b *testing.B) {
+		b.ReportAllocs() // 开启内存分配报告
+		for i := 0; i < b.N; i++ {
+			OldAdd(vals, 785, 3)
+		}
+	})
+}


### PR DESCRIPTION
新写的Add通过了add.test中的测试。并且我在测试中增加了新旧Add的测试对比，对比结果如下
pkg: github.com/ecodeclub/ekit/internal/slice
cpu: AMD Ryzen 7 6800H with Radeon Graphics         
Benchmark_Add
Benchmark_Add/Newadd
Benchmark_Add/Newadd-16         	23971473	        54.40 ns/op	      48 B/op	       1 allocs/op
Benchmark_Add/Oldadd
Benchmark_Add/Oldadd-16         	18766801	        69.49 ns/op	      80 B/op	       1 allocs/op