### PR TITLE
httpx: 增加暴露http.Response接口，Request增加error判断

### DIFF
--- a/net/httpx/request.go
+++ b/net/httpx/request.go
@@ -39,6 +39,9 @@ func NewRequest(ctx context.Context, method, url string) *Request {
 
 // JSONBody 使用 JSON body
 func (req *Request) JSONBody(val any) *Request {
+	if req.err != nil {
+		return req
+	}
 	req.req.Body = io.NopCloser(iox.NewJSONReader(val))
 	req.req.Header.Set("Content-Type", "application/json")
 	return req
@@ -50,6 +53,9 @@ func (req *Request) Client(cli *http.Client) *Request {
 }
 
 func (req *Request) AddHeader(key string, value string) *Request {
+	if req.err != nil {
+		return req
+	}
 	req.req.Header.Add(key, value)
 	return req
 }
@@ -57,6 +63,9 @@ func (req *Request) AddHeader(key string, value string) *Request {
 // AddParam 添加查询参数
 // 这个方法性能不好，但是好用
 func (req *Request) AddParam(key string, value string) *Request {
+	if req.err != nil {
+		return req
+	}
 	q := req.req.URL.Query()
 	q.Add(key, value)
 	req.req.URL.RawQuery = q.Encode()
@@ -71,7 +80,7 @@ func (req *Request) Do() *Response {
 	}
 	resp, err := req.client.Do(req.req)
 	return &Response{
-		Response: resp,
+		response: resp,
 		err:      err,
 	}
 }

--- a/net/httpx/response.go
+++ b/net/httpx/response.go
@@ -20,8 +20,8 @@ import (
 )
 
 type Response struct {
-	*http.Response
-	err error
+	response *http.Response
+	err      error
 }
 
 // JSONScan 将 Body 按照 JSON 反序列化为结构体
@@ -29,6 +29,10 @@ func (r *Response) JSONScan(val any) error {
 	if r.err != nil {
 		return r.err
 	}
-	err := json.NewDecoder(r.Body).Decode(val)
+	err := json.NewDecoder(r.response.Body).Decode(val)
 	return err
+}
+
+func (r *Response) GetResponse() *http.Response {
+	return r.response
 }

--- a/net/httpx/response_test.go
+++ b/net/httpx/response_test.go
@@ -33,7 +33,7 @@ func TestResponse_JSONScan(t *testing.T) {
 		{
 			name: "scan成功",
 			resp: &Response{
-				Response: &http.Response{
+				response: &http.Response{
 					Body: io.NopCloser(iox.NewJSONReader(User{Name: "Tom"})),
 				},
 			},


### PR DESCRIPTION
更新内容为以下：
（1）增加暴露http.Response接口，允许用户自己操作http.Response，这在一些需要诸如获取 StatusCode 字段的场景会用到。
（2）Request增加error判断：http.NewRequestWithContext返回错误时，req会为nil，此时调用 JSONBody() 等方法会发送panic。