### PR TITLE
httpx:增加error判断

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=

--- a/net/httpx/request.go
+++ b/net/httpx/request.go
@@ -39,6 +39,9 @@ func NewRequest(ctx context.Context, method, url string) *Request {
 
 // JSONBody 使用 JSON body
 func (req *Request) JSONBody(val any) *Request {
+	if req.err != nil {
+		return req
+	}
 	req.req.Body = io.NopCloser(iox.NewJSONReader(val))
 	req.req.Header.Set("Content-Type", "application/json")
 	return req
@@ -50,6 +53,9 @@ func (req *Request) Client(cli *http.Client) *Request {
 }
 
 func (req *Request) AddHeader(key string, value string) *Request {
+	if req.err != nil {
+		return req
+	}
 	req.req.Header.Add(key, value)
 	return req
 }
@@ -57,6 +63,9 @@ func (req *Request) AddHeader(key string, value string) *Request {
 // AddParam 添加查询参数
 // 这个方法性能不好，但是好用
 func (req *Request) AddParam(key string, value string) *Request {
+	if req.err != nil {
+		return req
+	}
 	q := req.req.URL.Query()
 	q.Add(key, value)
 	req.req.URL.RawQuery = q.Encode()

--- a/net/httpx/request_test.go
+++ b/net/httpx/request_test.go
@@ -40,6 +40,10 @@ func TestRequest_JSONBody(t *testing.T) {
 	req = req.JSONBody(User{})
 	assert.NotNil(t, req.req.Body)
 	assert.Equal(t, "application/json", req.req.Header.Get("Content-Type"))
+
+	req2 := NewRequest(context.Background(), http.MethodGet, "://localhost:80/a")
+	assert.NotNil(t, req2.err)
+	assert.Nil(t, req2.req)
 }
 
 func TestRequest_Do(t *testing.T) {
@@ -103,6 +107,10 @@ func TestRequest_AddParam(t *testing.T) {
 		AddParam("key1", "value1").
 		AddParam("key2", "value2")
 	assert.Equal(t, "http://localhost?key1=value1&key2=value2", req.req.URL.String())
+
+	req2 := NewRequest(context.Background(), http.MethodGet, "://localhost:80/a")
+	assert.NotNil(t, req2.err)
+	assert.Nil(t, req2.req)
 }
 
 func TestRequestAddHeader(t *testing.T) {
@@ -111,14 +119,12 @@ func TestRequestAddHeader(t *testing.T) {
 		AddHeader("head1", "val1").AddHeader("head1", "val2")
 	vals := req.req.Header.Values("head1")
 	assert.Equal(t, []string{"val1", "val2"}, vals)
+
+	req2 := NewRequest(context.Background(), http.MethodGet, "://localhost:80/a")
+	assert.NotNil(t, req2.err)
+	assert.Nil(t, req2.req)
 }
 
 type User struct {
 	Name string
-}
-
-func TestNewRequest_ReturnError(t *testing.T) {
-	req := NewRequest(context.Background(), http.MethodGet, "://localhost:80/a")
-	assert.NotNil(t, req.err)
-	assert.Nil(t, req.req)
 }

--- a/net/httpx/request_test.go
+++ b/net/httpx/request_test.go
@@ -116,3 +116,9 @@ func TestRequestAddHeader(t *testing.T) {
 type User struct {
 	Name string
 }
+
+func TestNewRequest_ReturnError(t *testing.T) {
+	req := NewRequest(context.Background(), http.MethodGet, "://localhost:80/a")
+	assert.NotNil(t, req.err)
+	assert.Nil(t, req.req)
+}


### PR DESCRIPTION
修改一个bug: http.NewRequestWithContext()返回error时，req为nil，后面调用JSONBody()等方法会发送panic