### PR TITLE
为ekit增加 devcontainer，修复spi test在make ut中无法通过的问题

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.go",
+                "eamodio.gitlens",
+                "ms-vscode.makefile-tools"
+            ]
+        }
+    }
+}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -race -coverprofile=cover.out ./...
+        run: make ut-coverage
 
       - name: Post Coverage
         uses: codecov/codecov-action@v2

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ bench:
 ut:
 	@go test -tags=goexperiment.arenas -race ./...
 
+.PHONY:	ut-coverage
+ut-coverage:
+	@go test -tags=goexperiment.arenas -race -coverprofile=cover.out ./...
+
 .PHONY:	setup
 setup:
 	@sh ./.script/setup.sh

--- a/spi/testdata/user_service/a.go
+++ b/spi/testdata/user_service/a.go
@@ -14,7 +14,7 @@
 package main
 
 // 测试用
-//go:generate go build -race --buildmode=plugin   -o a.so ./a.go
+//go:generate go build -race -tags=goexperiment.arenas --buildmode=plugin -o a.so ./a.go
 
 type UserService struct{}
 

--- a/spi/testdata/user_service2/a/a.go
+++ b/spi/testdata/user_service2/a/a.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go build  -race --buildmode=plugin  -o ../a.so ./a.go
+//go:generate go build -race -tags=goexperiment.arenas --buildmode=plugin -o ../a.so ./a.go
 
 package main
 

--- a/spi/testdata/user_service2/b/b.go
+++ b/spi/testdata/user_service2/b/b.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go build -race --buildmode=plugin   -o ../b.so ./b.go
+//go:generate go build -race -tags=goexperiment.arenas --buildmode=plugin -o ../b.so ./b.go
 package main
 
 // 测试用

--- a/spi/testdata/user_service3/a.go
+++ b/spi/testdata/user_service3/a.go
@@ -16,7 +16,7 @@ package main
 
 // 测试用
 
-//go:generate go build -race --buildmode=plugin   -o a.so ./a.go
+//go:generate go build -race -tags=goexperiment.arenas --buildmode=plugin -o a.so ./a.go
 
 type UserService struct{}
 


### PR DESCRIPTION
1. 增加devcontainer, 方便windows用户开发并且可以统一开发环境的golang version
2. 修复编译参数不统一导致的spi test在make ut中无法通过的问题