### PR TITLE
mapx 增加 merge 方法

### DIFF
--- a/mapx/map.go
+++ b/mapx/map.go
@@ -72,3 +72,31 @@ func ToMap[K comparable, V any](keys []K, values []V) (m map[K]V, err error) {
 	}
 	return
 }
+
+// Merge 如果同一个键对应多个值，则会使用最后一个值
+func Merge[K comparable, V any](ms ...map[K]V) map[K]V {
+	fc := func(val1, val2 V) V {
+		return val2
+	}
+	return MergeFunc(fc, ms...)
+}
+
+// MergeFunc 如果同一个键对应多个值，需要指定合并方式
+func MergeFunc[K comparable, V any](mergeFunc func(val1, val2 V) V, ms ...map[K]V) map[K]V {
+	total := 0
+	for _, m := range ms {
+		total += len(m)
+	}
+	merged := make(map[K]V, total)
+
+	for _, m := range ms {
+		for k, v := range m {
+			if value, ok := merged[k]; ok {
+				merged[k] = mergeFunc(value, v)
+			} else {
+				merged[k] = v
+			}
+		}
+	}
+	return merged
+}

--- a/mapx/map_example_test.go
+++ b/mapx/map_example_test.go
@@ -62,3 +62,36 @@ func (m MockKey) Equals(key any) bool {
 	}
 	return true
 }
+
+func ExampleMerge() {
+	m1 := map[int]int{1: 1, 2: 2, 3: 3}
+	m2 := map[int]int{4: 4, 5: 5, 6: 6}
+	got := mapx.Merge(m1, m2)
+	fmt.Println(got)
+
+	m3 := map[int]int{1: 1, 2: 2, 3: 3}
+	m4 := map[int]int{1: 5, 2: 6, 3: 7}
+	got = mapx.Merge(m3, m4)
+	fmt.Println(got)
+
+	var m map[int]int
+	got = mapx.Merge(m)
+	fmt.Println(got == nil) // 不会返回 nil map
+
+	// Output:
+	// map[1:1 2:2 3:3 4:4 5:5 6:6]
+	// map[1:5 2:6 3:7]
+	// false
+}
+
+func ExampleMergeFunc() {
+	m1 := map[int]int{1: 1, 2: 2, 3: 3}
+	m2 := map[int]int{1: 2, 2: 3, 3: 4}
+	got := mapx.MergeFunc(func(val1, val2 int) int {
+		return val1 + val2
+	}, m1, m2)
+	fmt.Println(got)
+
+	// Output:
+	// map[1:3 2:5 3:7]
+}

--- a/mapx/map_test.go
+++ b/mapx/map_test.go
@@ -229,7 +229,7 @@ func TestMerge(t *testing.T) {
 		1: 1, 2: 3, 3: 3, 4: 5,
 	}
 	got = Merge(input2...)
-	assert.Equal(t, want2, want2)
+	assert.Equal(t, want2, got)
 }
 
 func TestMergeFunc(t *testing.T) {

--- a/mapx/map_test.go
+++ b/mapx/map_test.go
@@ -208,3 +208,54 @@ func TestToMap(t *testing.T) {
 		assert.Equal(t, c.result, result)
 	}
 }
+
+func TestMerge(t *testing.T) {
+	input1 := []map[int]int{
+		{1: 1, 2: 2},
+		{3: 3, 4: 4},
+	}
+	want1 := map[int]int{
+		1: 1, 2: 2, 3: 3, 4: 4,
+	}
+	got := Merge(input1...)
+	assert.Equal(t, want1, got)
+
+	input2 := []map[int]int{
+		{1: 1, 2: 2},
+		{3: 3, 4: 4},
+		{2: 3, 4: 5},
+	}
+	want2 := map[int]int{
+		1: 1, 2: 3, 3: 3, 4: 5,
+	}
+	got = Merge(input2...)
+	assert.Equal(t, want2, want2)
+}
+
+func TestMergeFunc(t *testing.T) {
+	input1 := []map[int]int{
+		{1: 1, 2: 2},
+		{1: 3, 2: 4},
+		{3: 3, 4: 4},
+	}
+	want1 := map[int]int{
+		1: 4, 2: 6, 3: 3, 4: 4,
+	}
+	got := MergeFunc(func(val1, val2 int) int {
+		return val1 + val2
+	}, input1...)
+	assert.Equal(t, want1, got)
+
+	input2 := []map[int]int{
+		{1: 1, 2: 2},
+		{1: 3, 2: 4},
+		{3: 3, 4: 4},
+	}
+	want2 := map[int]int{
+		1: 3, 2: 8, 3: 3, 4: 4,
+	}
+	got = MergeFunc(func(val1, val2 int) int {
+		return val1 * val2
+	}, input2...)
+	assert.Equal(t, want2, got)
+}


### PR DESCRIPTION
#275 mapx: 支持 Merge 方法
增加两个函数：
1. Merge 直接合并，存在冲突的键值对则直接覆盖
2. MergeFunc 合并，存在冲突的键值对需要指定合并方式