### PR TITLE
增加DerefPtr泛型解引用函数

### DIFF
--- a/ptr.go
+++ b/ptr.go
@@ -17,3 +17,11 @@ package ekit
 func ToPtr[T any](t T) *T {
 	return &t
 }
+
+func DerefPtr[T any](ptr *T) T {
+	if ptr == nil {
+		var zero T
+		return zero
+	}
+	return *ptr
+}

--- a/ptr.go
+++ b/ptr.go
@@ -18,6 +18,7 @@ func ToPtr[T any](t T) *T {
 	return &t
 }
 
+// DerefPtr 做空指针安全的解引用：nil 返回零值。
 func DerefPtr[T any](ptr *T) T {
 	if ptr == nil {
 		var zero T

--- a/ptr_test.go
+++ b/ptr_test.go
@@ -25,3 +25,13 @@ func TestToPtr(t *testing.T) {
 	res := ToPtr[int](i)
 	assert.Equal(t, &i, res)
 }
+
+func TestDerefPtr(t *testing.T) {
+	i := 12
+	valueI := DerefPtr(&i)
+	assert.Equal(t, 12, valueI)
+
+	var ptrJ *string
+	valueJ := DerefPtr(ptrJ)
+	assert.Equal(t, "", valueJ)
+}


### PR DESCRIPTION
* DerefPtr对于传入的指针进行安全的指针解引用，若引用指针为nil则返回该类型的空值，实现一些指针字段传递时不用多写一段判空的逻辑；